### PR TITLE
Results and Cancellation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ PACKAGES = find_packages(exclude="tests")
 
 INSTALL_REQUIRES = [
     "virtool_core @ git+https://github.com/virtool/virtool-core",
-    "click",
-    "docker",
+    "asyncclick",
     "motor",
     "uvloop",
     "aiohttp",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ PACKAGES = find_packages(exclude="tests")
 
 INSTALL_REQUIRES = [
     "virtool_core @ git+https://github.com/virtool/virtool-core",
-    "asyncclick",
+    "click",
     "motor",
     "uvloop",
     "aiohttp",

--- a/tests/runtime/db/test_db.py
+++ b/tests/runtime/db/test_db.py
@@ -5,7 +5,7 @@ from virtool_workflow_runtime import runtime
 from virtool_workflow_runtime.db import VirtoolDatabase
 from virtool_workflow_runtime.discovery import discover_workflow
 from virtool_workflow.fixtures.scope import WorkflowFixtureScope
-from virtool_workflow_runtime.config.environment import db_name, db_connection_string
+from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
 from virtool_workflow import hooks
 
 EXAMPLE_WORKFLOW_PATH = Path(sys.path[0]).joinpath("tests/example_workflow.py")

--- a/tests/runtime/db/test_db.py
+++ b/tests/runtime/db/test_db.py
@@ -6,6 +6,7 @@ from virtool_workflow_runtime.db import VirtoolDatabase
 from virtool_workflow_runtime.discovery import discover_workflow
 from virtool_workflow.fixtures.scope import WorkflowFixtureScope
 from virtool_workflow_runtime.config.environment import db_name, db_connection_string
+from virtool_workflow import hooks
 
 EXAMPLE_WORKFLOW_PATH = Path(sys.path[0]).joinpath("tests/example_workflow.py")
 
@@ -28,3 +29,31 @@ async def test_updates_sent_to_mongo():
 
     for update in ("Started up", "Step", "Cleaned up"):
         assert update in updates
+
+
+async def test_results_stored_when_callback_set():
+
+    with WorkflowFixtureScope() as fixtures:
+        db: VirtoolDatabase = await fixtures.instantiate(VirtoolDatabase)
+        await db["analyses"].insert_one({"_id": "1"})
+
+        callback = db.store_result_callback("1", db["analyses"], await fixtures.get_or_instantiate("temp_path"))
+
+        hooks.on_result(callback, once=True)
+
+        result = {}
+
+        await hooks.on_result.trigger(None, result)
+
+        document = await db["analyses"].find_one({"_id": "1"})
+
+        assert document["results"] == result
+        assert document["ready"]
+
+
+
+
+
+
+
+

--- a/tests/runtime/redis/test_redis.py
+++ b/tests/runtime/redis/test_redis.py
@@ -8,7 +8,7 @@ from virtool_workflow_runtime._redis import \
     monitor_cancel, \
     VIRTOOL_JOBS_CANCEL_CHANNEL
 from virtool_workflow_runtime.config.configuration import redis_connection_string, redis_job_list_name
-from virtool_workflow_runtime.runtime import execute_from_redis, hooks, on_cancelled, \
+from virtool_workflow_runtime.runtime import execute_from_redis, hooks, \
     execute_while_watching_for_cancellation
 
 JOB_IDs = [str(n) for n in range(3)]
@@ -72,7 +72,7 @@ async def test_execute_from_redis_with_cancellation(test_workflow):
     def failure():
         failure.called = True
 
-    @on_cancelled
+    @hooks.on_cancelled
     def cancelled():
         cancelled.called = True
 

--- a/tests/runtime/redis/test_redis.py
+++ b/tests/runtime/redis/test_redis.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures._base
 
 from virtool_workflow import WorkflowError
 from virtool_workflow_runtime._redis import \
@@ -85,9 +86,11 @@ async def test_execute_from_redis_with_cancellation(test_workflow):
 
         try:
             await running
-        except (asyncio.CancelledError, WorkflowError) as e:
+        except (asyncio.CancelledError, concurrent.futures._base.CancelledError, WorkflowError) as e:
             if isinstance(e, WorkflowError):
-                assert isinstance(e.cause, asyncio.CancelledError)
+                if not isinstance(e.cause, asyncio.CancelledError):
+                    assert isinstance(e.cause, concurrent.futures._base.CancelledError)
+
             assert failure.called
             assert cancelled.called
             return

--- a/tests/runtime/test_config.py
+++ b/tests/runtime/test_config.py
@@ -1,7 +1,6 @@
 import os
 from virtool_workflow_runtime.config import environment
 from virtool_workflow.fixtures.scope import WorkflowFixtureScope
-from virtool_workflow_runtime.config.configuration import VirtoolConfiguration
 
 editor = environment.environment_variable_fixture("editor", "EDITOR", type_=str, default="/usr/bin/nano")
 
@@ -42,16 +41,3 @@ async def test_types():
 
         assert integer_ == 49
 
-
-async def test_use_config():
-
-    with WorkflowFixtureScope() as fixtures:
-        redis_connection_string = await fixtures.instantiate(environment.redis_connection_string)
-        config: VirtoolConfiguration = await fixtures.instantiate(VirtoolConfiguration)
-
-        assert config.redis_connection_string == environment.redis_connection_string()
-        assert id(redis_connection_string) == id(config.redis_connection_string)
-        assert id(fixtures["no_sentry"]) == id(config.no_sentry)
-        assert config.no_sentry == environment.no_sentry()
-        assert config.mem == environment.mem()
-        assert config.db_connection_string == environment.db_connection_string()

--- a/tests/runtime/test_runtime_hooks.py
+++ b/tests/runtime/test_runtime_hooks.py
@@ -28,7 +28,7 @@ async def test_on_failure_triggered():
 
     failure_called = False
 
-    @hooks.on_failure
+    @hooks.on_failure(once=True)
     def failure_callback(error):
         nonlocal failure_called
         failure_called = True
@@ -64,6 +64,8 @@ async def test_on_failure_not_triggered_when_successful():
     result = await runtime.execute("1", workflow)
 
     assert result["SUCCESS"]
+
+    hooks.on_failure.callbacks.remove(failure_callback)
 
 
 

--- a/tests/test_decorator_api.py
+++ b/tests/test_decorator_api.py
@@ -1,0 +1,40 @@
+import sys
+
+from virtool_workflow import startup, cleanup, step
+from virtool_workflow.decorator_api import collect
+from virtool_workflow.execution.execution import execute
+
+
+@startup
+def first(result: dict):
+    result["startup"] = True
+
+
+@step
+def step_z(result: dict):
+    result["step"] = True
+
+
+@step
+def step_a(result: dict):
+    result["step2"] = True
+    assert result["step"]
+
+
+@cleanup
+def last(result: dict):
+    result["cleanup"] = True
+
+
+async def test_decorator_api_workflow():
+    workflow = collect(sys.modules[__name__])
+
+    result = await execute(workflow)
+
+    assert result["startup"]
+    assert result["step"]
+    assert result["step2"]
+    assert result["cleanup"]
+
+
+

--- a/virtool_workflow/__init__.py
+++ b/virtool_workflow/__init__.py
@@ -8,6 +8,7 @@ from virtool_workflow.fixtures.scope import \
     WorkflowFixtureNotAvailable
 from virtool_workflow.fixtures.workflow_fixture import WorkflowFixture, fixture
 from virtool_workflow.workflow import Workflow
+from virtool_workflow.decorator_api import step, cleanup, startup
 
 __fixtures__ = [
     "virtool_workflow.storage.paths"
@@ -25,5 +26,8 @@ __all__ = [
     "WorkflowFixtureMultipleYield",
     "WorkflowFixture",
     "fixture",
-    "Workflow"
+    "Workflow",
+    "step",
+    "cleanup",
+    "startup",
 ]

--- a/virtool_workflow/analysis/read_paths.py
+++ b/virtool_workflow/analysis/read_paths.py
@@ -125,6 +125,7 @@ async def reads_path(
     else:
         hooks.on_workflow_failure(delete_cache_if_not_ready, once=True)
         hooks.on_workflow_failure(delete_analysis, once=True)
+        hooks.on_result(store_analysis_result, once=True)
 
         _, fq = await scope.instantiate(prepared_reads_and_fastqc)
         await create_cache(fq, database, analysis_args, trimming_parameters, trimming_output_path, cache_path)

--- a/virtool_workflow/analysis/read_paths.py
+++ b/virtool_workflow/analysis/read_paths.py
@@ -125,7 +125,9 @@ async def reads_path(
     else:
         hooks.on_workflow_failure(delete_cache_if_not_ready, once=True)
         hooks.on_workflow_failure(delete_analysis, once=True)
-        hooks.on_result(store_analysis_result, once=True)
+        hooks.on_result(VirtoolDatabase.store_result_callback(analysis_args.analysis_id,
+                                                              database["analyses"],
+                                                              analysis_args.path), once=True)
 
         _, fq = await scope.instantiate(prepared_reads_and_fastqc)
         await create_cache(fq, database, analysis_args, trimming_parameters, trimming_output_path, cache_path)

--- a/virtool_workflow/analysis/utils.py
+++ b/virtool_workflow/analysis/utils.py
@@ -25,3 +25,4 @@ def make_legacy_read_paths(
         paired: bool
 ) -> ReadPaths:
     return _make_paired_paths(reads_dir_path, paired, lambda n: f"reads_{n}.fastq")
+

--- a/virtool_workflow/decorator_api.py
+++ b/virtool_workflow/decorator_api.py
@@ -1,36 +1,49 @@
+"""Create Workflows by decorating module scope functions."""
 from types import ModuleType
 
 from virtool_workflow import Workflow
 
 
-def startup(func):
-    func._is_workflow_startup_function = True
-    return func
+def workflow_marker(marker_name: str):
+    """Create a decorator to mark a function for use within a workflow."""
+    def _marker(func):
+        func.__workflow_marker__ = marker_name
+        return func
+    return _marker
 
 
-def cleanup(func):
-    func._is_workflow_cleanup_function = True
-    return func
-
-
-def step(func):
-    func._is_workflow_step_function = True
-    return func
+startup = workflow_marker("startup")
+"""Mark a function as a workflow startup function."""
+cleanup = workflow_marker("cleanup")
+"""Mark a function as a workflow cleanup function."""
+step = workflow_marker("step")
+"""Mark a function as a workflow step function."""
 
 
 def collect(module: ModuleType) -> Workflow:
+    """
+    Build a Workflow using the functions in a module which have been marked using a `workflow_marker`.
 
-    # From python 3.7+ dictionary order is guaranteed to be insertion order.
-    # So, for a module, __dict__ is in definition order.
+    Since Python 3.7 dictionaries maintain insertion order. A side effect of this is that a module's
+    __dict__ attribute maintains **definition** order, since attributes are added to the dict as they
+    are defined.
+
+    The same is true in Python 3.6, however it is an implementation detail. This function may not work
+    as intended in versions of python previous to 3.6 as it assumes that a module's __dict__ attribute is
+    in definition order.
+
+    :param module: A module containing functions tagged by the `workflow_marker` decorators.
+    :return Workflow: A workflow build using the tagged functions.
+    """
 
     workflow = Workflow()
-    for value in module.__dict__.values():
-        if hasattr(value, "_is_workflow_startup_function"):
-            workflow.startup(value)
-        elif hasattr(value, "_is_workflow_step_function"):
-            workflow.step(value)
-        elif hasattr(value, "_is_workflow_cleanup_function"):
-            workflow.cleanup(value)
+    for marked in [value for value in module.__dict__.values() if hasattr(value, "__workflow_marker__")]:
+        if marked.__workflow_marker__ == "startup":
+            workflow.startup(marked)
+        elif marked.__workflow_marker__ == "step":
+            workflow.step(marked)
+        elif marked.__workflow_marker__ == "cleanup":
+            workflow.cleanup(marked)
 
     return workflow
 

--- a/virtool_workflow/decorator_api.py
+++ b/virtool_workflow/decorator_api.py
@@ -1,0 +1,36 @@
+import sys
+from virtool_workflow import Workflow
+from types import ModuleType
+
+
+class DelegatedAttribute:
+
+    def __init__(self, delegate_name):
+        self._delegate_name = delegate_name
+
+    def __set_name__(self, owner, name):
+        self._name = name
+
+    def __get__(self, instance, owner):
+        if instance:
+            return getattr(getattr(instance, self._delegate_name), self._name)
+        else:
+            return getattr(getattr(owner, self._delegate_name), self._name)
+
+
+workflow = Workflow
+
+
+class WorkflowDecoratorModule(ModuleType):
+    _workflow = Workflow()
+    startup = DelegatedAttribute("_workflow")
+    step = DelegatedAttribute("_workflow")
+    cleanup = DelegatedAttribute("_workflow")
+
+
+sys.modules[__name__] = WorkflowDecoratorModule(__name__, __doc__)
+
+
+
+
+

--- a/virtool_workflow/execution/execution.py
+++ b/virtool_workflow/execution/execution.py
@@ -5,8 +5,10 @@ from ..fixtures.scope import WorkflowFixtureScope
 from typing import Dict, Any
 
 
-async def execute(workflow: Workflow) -> Dict[str, Any]:
+async def execute(workflow: Workflow, scope: WorkflowFixtureScope = None) -> Dict[str, Any]:
     """Execute a workflow."""
-    with WorkflowFixtureScope() as fixtures:
+    if not scope:
+        scope = WorkflowFixtureScope()
+    with scope as fixtures:
         return await workflow_executor.WorkflowExecution(workflow, fixtures)
 

--- a/virtool_workflow/execution/workflow_executor.py
+++ b/virtool_workflow/execution/workflow_executor.py
@@ -119,7 +119,9 @@ class WorkflowExecution:
         try:
             return await self._execute()
         except Exception as e:
-            await hooks.on_workflow_failure.trigger(self, e)
+            if not isinstance(e, WorkflowError):
+                e = WorkflowError(cause=e, workflow=self.workflow, context=self)
+            await hooks.on_workflow_failure.trigger(self.workflow, e)
             raise e
 
     async def _execute(self) -> Dict[str, Any]:

--- a/virtool_workflow/execution/workflow_executor.py
+++ b/virtool_workflow/execution/workflow_executor.py
@@ -40,6 +40,9 @@ class WorkflowError(Exception):
 
         super().__init__(str(cause))
 
+    def __str__(self):
+        return f"{self.traceback_data}"
+
 
 State = Enum("State", "WAITING STARTUP RUNNING CLEANUP FINISHED")
 

--- a/virtool_workflow/execution/workflow_executor.py
+++ b/virtool_workflow/execution/workflow_executor.py
@@ -16,7 +16,7 @@ class WorkflowError(Exception):
             self,
             cause: Exception,
             workflow: Workflow,
-            context: "WorkflowExecution",
+            context: Optional["WorkflowExecution"],
             max_traceback_depth: int = 50
     ):
         """

--- a/virtool_workflow_runtime/_redis.py
+++ b/virtool_workflow_runtime/_redis.py
@@ -39,7 +39,9 @@ async def redis_channel(redis: aioredis.Redis, channel: str):
 async def redis_list(redis: aioredis.Redis, list_name: str):
     """Expose redis list as async generator."""
     while True:
-        yield await redis.lpop(list_name, encoding="utf-8")
+        message = await redis.lpop(list_name, encoding="utf-8")
+        if message:
+            yield message
 
 
 async def monitor_cancel(redis: aioredis.Redis, current_job_id: str, task: asyncio.Task) -> asyncio.Task:

--- a/virtool_workflow_runtime/_redis.py
+++ b/virtool_workflow_runtime/_redis.py
@@ -5,8 +5,11 @@ from contextlib import asynccontextmanager
 
 import aioredis
 
-VIRTOOL_JOBS_CHANNEL = "channel:dispatch"
 VIRTOOL_JOBS_CANCEL_CHANNEL = "channel:cancel"
+
+
+class JobCancelledViaRedis(RuntimeError):
+    """Raised when a currently executing job is cancelled via the redis cancellation queue."""
 
 
 @asynccontextmanager
@@ -16,7 +19,7 @@ async def connect(address: Optional[str]) -> aioredis.Redis:
 
     :param address: The URL for the redis database, when not provided the value of
             the VIRTOOL_REDIS_ADDRESS environment variable is used.
-    :return Iterator[aioredis.Redis]: A connection to Redis
+    :return Iterator[aioredis.Redis]: A connection to Redis.
     """
     redis_ = await aioredis.create_redis_pool(address, loop=asyncio.get_event_loop())
 
@@ -26,29 +29,32 @@ async def connect(address: Optional[str]) -> aioredis.Redis:
     await redis_.wait_closed()
 
 
-async def job_id_queue(redis_connection: str,
-                       channel: str = VIRTOOL_JOBS_CHANNEL):
+async def redis_channel(redis: aioredis.Redis, channel: str):
+    """Expose redis pub/sub channel as an async generator."""
+    (channel_,) = await redis.subscribe(channel)
+    async for message in channel_.iter(encoding="utf-8"):
+        yield message
+
+
+async def redis_list(redis: aioredis.Redis, list_name: str):
+    """Expose redis list as async generator."""
+    while True:
+        yield await redis.lpop(list_name, encoding="utf-8")
+
+
+async def monitor_cancel(redis: aioredis.Redis, current_job_id: str, task: asyncio.Task) -> asyncio.Task:
     """
-    Exposes the redis jobs channel for Virtool Jobs as an async generator
+    Watch the cancel channel in redis for the current job id.
 
-    :param redis_connection: The URL address of the redis database, if none provided
-        the value of the environment variable VIRTOOL_REDIS_ADDRESS is used
-    :param channel: The redis channel to which job id's are published
-    :return Iterator[str]: The database (mongo) id's for each job to be executed
-    :raise ConnectionRefusedError: When redis is not available at the given URL
+    If the current job id is found, cancel the task.
+
+    :param redis: The redis connection.
+    :param current_job_id: The id of the current job.
+    :param task: The asyncio task in which the job is being executed.
+
+    :return: The asyncio task object after it has been cancelled.
     """
-    async with connect(redis_connection) as redis:
-        (job_ids,) = await redis.subscribe(channel)
-        async for message in job_ids.iter():
-            yield str(message, encoding="utf-8")
-
-
-class JobCancelledViaRedis(RuntimeError):
-    """Raised when a currently executing job is cancelled via the redis cancellation queue."""
-
-
-async def monitor_cancel(redis_connection: str, current_job_id: str, task: asyncio.Task) -> asyncio.Task:
-    async for id_ in job_id_queue(redis_connection, VIRTOOL_JOBS_CANCEL_CHANNEL):
+    async for id_ in redis_channel(redis, VIRTOOL_JOBS_CANCEL_CHANNEL):
         if id_ == current_job_id:
             task.cancel()
             return task

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -1,12 +1,15 @@
 """Command Line Interface to virtool_workflow"""
+import os
 from pathlib import Path
 
-import click
+import asyncclick as click
 import uvloop
 
 from virtool_workflow.execution.execution import execute
+from virtool_workflow.fixtures.scope import WorkflowFixtureScope
 from . import discovery
 from . import runtime
+from virtool_workflow_runtime.config.configuration import create_config, options
 
 JOB_ID_ENV = "VIRTOOL_JOB_ID"
 
@@ -20,31 +23,71 @@ def cli():
 def workflow_file_option(func):
     """Option to provide workflow file."""
     return click.option(
-        func,
         "-f",
         default="workflow.py",
         type=click.Path(exists=True),
         help="python module containing an instance of `virtool_workflow.Workflow`"
-    )
+    )(func)
 
 
-@workflow_file_option
+def apply_config_options(func):
+    for _, option_name, type_, _, help_, _ in options:
+        func = click.option(option_name, type=type_, help=help_)(func)
+
+    return func
+
+
+@apply_config_options
 @click.argument("job_id", nargs=1, envvar=JOB_ID_ENV)
-@cli.command()
-async def run(file: str, job_id: str):
-    """Run a workflow and send updates to Virtool."""
-    workflow, _ = discovery.run_discovery(Path(file), Path(file).parent / "fixtures.py")
-
-    await runtime.execute(job_id, workflow)
-
-
 @workflow_file_option
 @cli.command()
-async def run_local(f: str):
+async def run(file: str, job_id: str, **kwargs):
+    """Run a workflow and send updates to Virtool."""
+    with WorkflowFixtureScope() as scope:
+        await create_config(scope, **kwargs)
+        workflow, _ = discovery.run_discovery(Path(file), Path(file).parent / "fixtures.py")
+
+        await runtime.execute(job_id, workflow, scope)
+
+
+@apply_config_options
+@workflow_file_option
+@cli.command()
+async def run_local(f: str, **kwargs):
     """Run a workflow locally, without runtime specific dependencies."""
-    await execute(discovery.discover_workflow(Path(f).absolute()))
+    with WorkflowFixtureScope() as scope:
+        await create_config(scope=scope, **kwargs)
+        await execute(discovery.discover_workflow(Path(f).absolute()), scope)
+
+
+@apply_config_options
+@cli.command()
+async def print_config(**kwargs):
+    """Print the configuration which would be used with the given arguments."""
+    with WorkflowFixtureScope() as scope:
+        config = await create_config(scope, **kwargs)
+
+        for name, value in vars(config).items():
+            print(f"{name}: {value}")
+
+
+@apply_config_options
+@cli.command()
+async def create_env_script(**kwargs):
+    """Create a bash script to set environment variables based on default values and provided arguments."""
+    commands = []
+    for name, _, _, _, _, fixture in options:
+        if name in kwargs and kwargs[name] is not None:
+            commands.append(f"export {fixture.environment_variable}={kwargs[name]}")
+        else:
+            commands.append(f"export {fixture.environment_variable}={fixture.default_value}")
+    for cmd in commands:
+        print(cmd)
+
+
+
 
 
 def cli_main():
     """Main pip entrypoint."""
-    cli()
+    cli(_anyio_backend="asyncio")

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -15,7 +15,7 @@ JOB_ID_ENV = "VIRTOOL_JOB_ID"
 
 @click.group()
 def cli():
-    """Main cli entrypoint."""
+    """Command Line Interface for Virtool Workflows."""
     uvloop.install()
 
 

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -1,5 +1,4 @@
 """Command Line Interface to virtool_workflow"""
-import os
 from pathlib import Path
 
 import asyncclick as click
@@ -7,9 +6,9 @@ import uvloop
 
 from virtool_workflow.execution.execution import execute
 from virtool_workflow.fixtures.scope import WorkflowFixtureScope
+from virtool_workflow_runtime.config.configuration import create_config, options
 from . import discovery
 from . import runtime
-from virtool_workflow_runtime.config.configuration import create_config, options
 
 JOB_ID_ENV = "VIRTOOL_JOB_ID"
 
@@ -83,9 +82,6 @@ async def create_env_script(**kwargs):
             commands.append(f"export {fixture.environment_variable}={fixture.default_value}")
     for cmd in commands:
         print(cmd)
-
-
-
 
 
 def cli_main():

--- a/virtool_workflow_runtime/config/configuration.py
+++ b/virtool_workflow_runtime/config/configuration.py
@@ -1,61 +1,97 @@
-from dataclasses import dataclass
+import os
+from typing import Any, Iterable, Type
+from types import SimpleNamespace
 
-from virtool_workflow import WorkflowFixture
-from virtool_workflow.fixtures.scope import WorkflowFixtureScope
-from virtool_workflow_runtime.config.environment import \
-    temp_path_str, data_path_str, proc, mem, redis_connection_string, no_sentry, \
-    dev_mode, db_name, db_connection_string
+from virtool_workflow import WorkflowFixtureScope
+from virtool_workflow_runtime.config.environment import environment_variable_fixture, ENV_VARIABLE_TYPE
 
-
-@dataclass(frozen=True)
-class VirtoolConfiguration(WorkflowFixture, param_names=["config", "configuration"]):
-    """Dataclass containing all configuration options."""
-    temp_path: str
-    data_path: str
-    proc: int
-    mem: int
-    redis_connection_string: str
-    no_sentry: bool
-    development_mode: bool
-    db_name: str
-    db_connection_string: str
-
-    @staticmethod
-    def __fixture__(
-            temp_path_str: str,
-            data_path_str: str,
-            proc: int,
-            mem: int,
-            redis_connection_string: str,
-            no_sentry: bool,
-            dev_mode: bool,
-            db_name: str,
-            db_connection_string: str
-    ) -> WorkflowFixture:
-        return VirtoolConfiguration(
-            data_path=data_path_str,
-            temp_path=temp_path_str,
-            proc=proc,
-            mem=mem,
-            redis_connection_string=redis_connection_string,
-            no_sentry=no_sentry,
-            development_mode=dev_mode,
-            db_name=db_name,
-            db_connection_string=db_connection_string
-        )
+DATA_PATH_ENV = "VT_DATA_PATH"
+TEMP_PATH_ENV = "VT_TEMP_PATH"
+PROC_ENV = "VT_PROC"
+MEM_ENV = "VT_MEM"
+REDIS_CONNECTION_STRING_ENV = "VT_REDIS_CONNECTION_STRING"
+REDIS_JOB_LIST_NAME_ENV = "VT_REDIS_JOB_LIST_NAME"
+NO_SENTRY_ENV = "VT_NO_SENTRY"
+DEVELOPMENT_MODE_ENV = "VT_DEV"
+MONGO_DATABASE_CONNECTION_STRING_ENV = "VT_DB_CONNECTION_STRING"
+MONGO_DATABASE_NAME_ENV = "VT_DB_NAME"
 
 
-def set_config_fixtures(config: VirtoolConfiguration, scope: WorkflowFixtureScope):
-    """Set the values of all config related fixtures based on the values in a VirtoolConfiguration."""
-    scope.add_instance(config.data_path, *data_path_str.param_names)
-    scope.add_instance(config.temp_path, *temp_path_str.param_names)
-    scope.add_instance(config.mem, *mem.param_names)
-    scope.add_instance(config.proc, *proc.param_names)
-    scope.add_instance(config.no_sentry, *no_sentry.param_names)
-    scope.add_instance(config.development_mode, *dev_mode.param_names)
-    scope.add_instance(config.db_name, *db_name.param_names)
-    scope.add_instance(config.db_connection_string, *db_connection_string.param_names)
-    scope.add_instance(config.redis_connection_string, *redis_connection_string.param_names)
-    scope.add_instance(config, *config.param_names)
+options = []
+
+
+def config_option(
+        name,
+        env,
+        default: Any = None,
+        type_: Type[ENV_VARIABLE_TYPE] = str,
+        alt_names: Iterable[str] = (),
+        help_: str = "",
+):
+    option_name = f"--{name}".replace("_", "-")
+
+    fixture = environment_variable_fixture(name, env, default, alt_names=alt_names, type_=type_)
+
+    options.append((name, option_name, type_, default, help_, fixture))
+
+    return fixture
+
+
+async def create_config(scope: WorkflowFixtureScope, **kwargs):
+    config = SimpleNamespace()
+    for name, _, _, _, _, fixture in options:
+        if name in kwargs and kwargs[name] is not None:
+            setattr(config, name, kwargs[name])
+            scope.add_instance(kwargs[name], *fixture.param_names)
+        else:
+            setattr(config, name, await scope.instantiate(fixture))
+
+    scope.add_instance(config, "config", "configuration")
+    return config
+
+
+temp_path_str = config_option("temp_path_str", TEMP_PATH_ENV, default=f"{os.getcwd()}/temp",
+                              help_="The path where temporary data should be stored.")
+
+data_path_str = config_option("data_path_str", DATA_PATH_ENV, default=f"{os.getcwd()}/virtool",
+                              help_="The path where persistent data should be stored.")
+
+proc = config_option("proc",
+                     PROC_ENV,
+                     alt_names=("number_of_processes", "process_limit"),
+                     default=2,
+                     help_="The number of cores available for a workflow.")
+
+mem = config_option("mem",
+                    MEM_ENV,
+                    alt_names=("memory_limit", "RAM_limit"),
+                    default=8,
+                    help_="The amount of RAM in GB available for use in a workflow.")
+
+redis_connection_string = config_option(
+    "redis_connection_str",
+    REDIS_CONNECTION_STRING_ENV,
+    alt_names=("redis_url", "redis_connection_string"),
+    default="redis://localhost:6379",
+    help_="The URL used to connect to redis.",
+)
+
+redis_job_list_name = config_option("job_list_name", REDIS_JOB_LIST_NAME_ENV, default="job_list",
+                                    help_="The name of the job list in redis.")
+
+no_sentry = config_option("no_sentry", NO_SENTRY_ENV, default=True, help_="Disable sentry reporting.")
+
+dev_mode = config_option("dev_mode", DEVELOPMENT_MODE_ENV, default=False,
+                         help_="enable development mode for more detailed logging.")
+
+db_name = config_option("db_name", MONGO_DATABASE_NAME_ENV, default="virtool",
+                        help_="""The name to use for the MongoDB database.""")
+
+db_connection_string = config_option(
+    "db_connection_string",
+    MONGO_DATABASE_CONNECTION_STRING_ENV,
+    alt_names=("db_conn_string", "db_conn_url", "db_connection_url"),
+    default="mongodb://localhost:27017",
+    help_="The URL used to connect to MongoDB.")
 
 

--- a/virtool_workflow_runtime/config/configuration.py
+++ b/virtool_workflow_runtime/config/configuration.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, Iterable, Type
 from types import SimpleNamespace
 
-from virtool_workflow import WorkflowFixtureScope
+from virtool_workflow import WorkflowFixtureScope, fixture
 from virtool_workflow_runtime.config.environment import environment_variable_fixture, ENV_VARIABLE_TYPE
 
 DATA_PATH_ENV = "VT_DATA_PATH"

--- a/virtool_workflow_runtime/config/environment.py
+++ b/virtool_workflow_runtime/config/environment.py
@@ -1,18 +1,7 @@
 """Fixtures for getting runtime configuration details."""
 import os
-from typing import Optional, Iterable, Type, Union
+from typing import Optional, Iterable, Type, Union, Any
 from virtool_workflow import fixture, WorkflowFixture
-
-TEMP_PATH_ENV = "VT_TEMP_PATH"
-DATA_PATH_ENV = "VT_DATA_PATH"
-PROC_ENV = "VT_PROC"
-MEM_ENV = "VT_MEM"
-REDIS_CONNECTION_STRING_ENV = "VT_REDIS_CONNECTION_STRING"
-NO_SENTRY_ENV = "VT_NO_SENTRY"
-DEVELOPMENT_MODE_ENV = "VT_DEV"
-MONGO_DATABASE_CONNECTION_STRING_ENV = "VT_DB_CONNECTION_STRING"
-MONGO_DATABASE_NAME_ENV = "VT_DB_NAME"
-
 
 ENV_VARIABLE_TYPE = Union[str, int, bool]
 
@@ -54,63 +43,16 @@ def environment_variable_fixture(
 
     _fixture.__name__ = _fixture.__qualname__ = name
 
-    return fixture(_fixture, alt_names=alt_names)
+    class _Fixture(WorkflowFixture, param_names=[name, *alt_names]):
+        default_value = default
+        environment_variable = variable
+
+        __fixture__ = _fixture
+
+    _Fixture.__name__ = _Fixture.__qualname__ = name
+
+    return _Fixture()
 
 
-temp_path_str = environment_variable_fixture("temp_path_str", TEMP_PATH_ENV, default=f"{os.getcwd()}/temp")
-"""The path where temporary data should be stored."""
-
-data_path_str = environment_variable_fixture("data_path_str", DATA_PATH_ENV, default=f"{os.getcwd()}/virtool")
-"""The path where persistent data should be stored."""
-
-proc = environment_variable_fixture("proc",
-                                    PROC_ENV,
-                                    alt_names=("number_of_processes", "process_limit"),
-                                    default=2)
-"""The number of cores available for a workflow."""
-
-mem = environment_variable_fixture("mem",
-                                   MEM_ENV,
-                                   alt_names=("memory_limit", "RAM_limit"),
-                                   default=8)
-"""The amount of RAM in GB available for use in a workflow."""
-
-redis_connection_string = environment_variable_fixture(
-    "redis_connection_str",
-    REDIS_CONNECTION_STRING_ENV,
-    alt_names=("redis_url", "redis_connection_string"),
-    default="redis://localhost:6379"
-)
-"""The URL used to connect to redis."""
-
-no_sentry = environment_variable_fixture("no_sentry", NO_SENTRY_ENV, default=True)
-"""Option to disable sentry."""
-
-dev_mode = environment_variable_fixture("dev_mode", DEVELOPMENT_MODE_ENV, default=False)
-"""Option to enable dev mode for more detailed logging."""
-
-db_name = environment_variable_fixture("db_name", MONGO_DATABASE_NAME_ENV, default="virtool")
-"""The name to use for the MongoDB database."""
-
-db_connection_string = environment_variable_fixture(
-    "db_connection_string",
-    MONGO_DATABASE_CONNECTION_STRING_ENV,
-    alt_names=("db_conn_string", "db_conn_url", "db_connection_url"),
-    default="mongodb://localhost:27017",
-)
-"""The URL used to connect to MongoDB."""
-
-__all__ = [
-    "no_sentry",
-    "dev_mode",
-    "db_name",
-    "db_connection_string",
-    "redis_connection_string",
-    "mem",
-    "proc",
-    "environment_variable_fixture",
-    "temp_path_str",
-    "data_path_str"
-]
 
 

--- a/virtool_workflow_runtime/config/environment.py
+++ b/virtool_workflow_runtime/config/environment.py
@@ -1,7 +1,8 @@
 """Fixtures for getting runtime configuration details."""
 import os
-from typing import Optional, Iterable, Type, Union, Any
-from virtool_workflow import fixture, WorkflowFixture
+from typing import Optional, Iterable, Type, Union
+
+from virtool_workflow import WorkflowFixture
 
 ENV_VARIABLE_TYPE = Union[str, int, bool]
 

--- a/virtool_workflow_runtime/db/db.py
+++ b/virtool_workflow_runtime/db/db.py
@@ -108,8 +108,8 @@ class VirtoolDatabase(WorkflowFixture, param_names=["database", "db"]):
             })
 
     @staticmethod
-    async def store_result_callback(id_: str, collection: Collection, file_results_location: Path):
-        def _store_results(_, results):
-            return VirtoolDatabase.store_result(id_, collection, results, file_results_location)
+    def store_result_callback(id_: str, collection: Collection, file_results_location: Path):
+        async def _store_results(_, results):
+            return await VirtoolDatabase.store_result(id_, collection, results, file_results_location)
 
         return _store_results

--- a/virtool_workflow_runtime/db/db.py
+++ b/virtool_workflow_runtime/db/db.py
@@ -107,3 +107,9 @@ class VirtoolDatabase(WorkflowFixture, param_names=["database", "db"]):
                 }
             })
 
+    @staticmethod
+    async def store_result_callback(id_: str, collection: Collection, file_results_location: Path):
+        def _store_results(_, results):
+            return VirtoolDatabase.store_result(id_, collection, results, file_results_location)
+
+        return _store_results

--- a/virtool_workflow_runtime/discovery.py
+++ b/virtool_workflow_runtime/discovery.py
@@ -6,6 +6,7 @@ from types import ModuleType
 from typing import List, Union, Iterable, Tuple, Optional
 
 from virtool_workflow import Workflow, WorkflowFixture
+from virtool_workflow.decorator_api import collect
 
 FixtureImportType = Iterable[
     Union[
@@ -80,7 +81,12 @@ def discover_workflow(path: Path) -> Workflow:
     """
     module = _import_module_from_file(path.name.rstrip(path.suffix), path)
 
-    return next(attr for attr in module.__dict__.values() if isinstance(attr, Workflow))
+    workflow = next((attr for attr in module.__dict__.values() if isinstance(attr, Workflow)), None)
+
+    if not workflow:
+        workflow = collect(module)
+
+    return workflow
 
 
 def run_discovery(

--- a/virtool_workflow_runtime/hooks.py
+++ b/virtool_workflow_runtime/hooks.py
@@ -1,3 +1,5 @@
+import asyncio
+from concurrent import futures
 from virtool_workflow import Hook, Workflow, WorkflowError, WorkflowFixtureScope
 from typing import Dict, Any
 
@@ -14,6 +16,15 @@ async def _trigger_on_finish_from_on_success(workflow: Workflow, _):
 @on_failure
 async def _trigger_on_finish_from_on_failure(error: WorkflowError):
     await on_finish.trigger(error.workflow)
+
+
+on_cancelled = Hook("on_cancelled", [Workflow, asyncio.CancelledError], None)
+
+
+@on_failure
+async def _trigger_on_cancelled(error: WorkflowError):
+    if isinstance(error.cause, asyncio.CancelledError) or isinstance(error.cause, futures.CancelledError):
+        await on_cancelled.trigger(error.workflow, error.cause)
 
 
 on_load_fixtures = Hook("on_load_fixtures", [WorkflowFixtureScope], return_type=None)

--- a/virtool_workflow_runtime/runtime.py
+++ b/virtool_workflow_runtime/runtime.py
@@ -13,13 +13,6 @@ from ._redis import monitor_cancel, redis_list, connect
 from .db import VirtoolDatabase
 from virtool_workflow_runtime.config.configuration import redis_connection_string, redis_job_list_name
 
-on_cancelled = hooks.Hook("on_cancelled", [Workflow, asyncio.CancelledError], None)
-
-
-@hooks.on_failure
-async def _trigger_on_cancelled(error: WorkflowError):
-    if isinstance(error.cause, asyncio.CancelledError) or isinstance(error.cause, futures.CancelledError):
-        await on_cancelled.trigger(error.workflow, error.cause)
 
 
 async def execute(

--- a/virtool_workflow_runtime/runtime.py
+++ b/virtool_workflow_runtime/runtime.py
@@ -6,7 +6,7 @@ from virtool_workflow.execution.workflow_executor import WorkflowExecution, Work
 from virtool_workflow.fixtures.scope import WorkflowFixtureScope
 from virtool_workflow.workflow import Workflow
 from . import hooks
-from ._redis import job_id_queue
+from ._redis import job_id_queue, VIRTOOL_JOBS_CANCEL_CHANNEL, VIRTOOL_JOBS_CHANNEL
 from .db import VirtoolDatabase
 from virtool_workflow_runtime.config.environment import redis_connection_string
 
@@ -59,6 +59,9 @@ async def _execute(job_id: str,
 
     return await executor
 
+
+async def execute_catching_cancellation(job_id, workflow):
+    pass
 
 async def execute_from_redis(workflow: Workflow):
     """Execute jobs from the Redis jobs list."""

--- a/virtool_workflow_runtime/runtime.py
+++ b/virtool_workflow_runtime/runtime.py
@@ -89,5 +89,9 @@ async def execute_while_watching_for_cancellation(job_id: str, workflow: Workflo
 async def execute_from_redis(workflow: Workflow):
     """Execute jobs from the Redis jobs list."""
     async for job_id in job_id_queue(redis_connection_string()):
-        yield await execute_while_watching_for_cancellation(job_id, workflow)
+        try:
+            yield await execute_while_watching_for_cancellation(job_id, workflow)
+        except asyncio.CancelledError:
+            continue
+
 

--- a/virtool_workflow_runtime/runtime.py
+++ b/virtool_workflow_runtime/runtime.py
@@ -2,6 +2,7 @@
 import asyncio
 import aioredis
 from typing import Dict, Any
+from concurrent import futures
 
 from virtool_workflow.execution.hooks import on_update, on_workflow_finish
 from virtool_workflow.execution.workflow_executor import WorkflowExecution, WorkflowError
@@ -77,7 +78,7 @@ async def execute_catching_cancellation(job_id, workflow):
     """Execute while catching :class:`asyncio.CancelledError` and triggering `on_failure` and `on_cancelled` hooks."""
     try:
         return await execute(job_id, workflow)
-    except asyncio.CancelledError as error:
+    except (asyncio.CancelledError, futures._base.CancelledError) as error:
         await hooks.on_failure.trigger(WorkflowError(cause=error, workflow=workflow, context=None))
         await on_cancelled.trigger(workflow, error)
         raise error


### PR DESCRIPTION
Resolves #30 
Resolves #31 

- Send results to the database upon completion using `on_results` hook. 
- Support job cancellation via Redis pub/sub channel "channel:cancel".
- Re-factor configuration fixtures to automatically create CLI options. 
- Override values in the fixture scope with values provided via CLI options. 
- Re-work job assignment to use Redis lists instead of pub/sub. 

Also includes a static style workflow API enabling the following syntax.

```python
from virtool_workflow import startup, cleanup, step

@startup
def _startup():
    ...

@step 
def _step():
    ...

@cleanup
def _cleanup():
    ...
```