### PR TITLE
Use `virtool-core` As Dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ PACKAGES = find_packages(exclude="tests")
 
 
 INSTALL_REQUIRES = [
-    "virtool-core",
-    "click",
-    "motor",
-    "uvloop",
-    "aiohttp",
+    "virtool-core==0.1.0",
+    "click==7.1.2",
+    "motor==2.3.0",
+    "uvloop==0.14.0",
+    "aiohttp==3.7.3",
     "aioredis==1.3.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ PACKAGES = find_packages(exclude="tests")
 
 
 INSTALL_REQUIRES = [
-    "virtool_core @ git+https://github.com/virtool/virtool-core",
+    "virtool-core",
     "click",
     "motor",
     "uvloop",


### PR DESCRIPTION
PyPi packages cannot depend on packages which are not hosted on PyPi.