### PR TITLE
Fix Workflow CLI

### DIFF
--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -42,7 +42,8 @@ async def _run(file: str, job_id: str, **kwargs):
         await create_config(scope, **kwargs)
         workflow, _ = discovery.run_discovery(Path(file), Path(file).parent / "fixtures.py")
 
-        await runtime.execute(job_id, workflow, scope)
+        result = await runtime.execute(job_id, workflow, scope)
+        print(result)
 
 
 @apply_config_options
@@ -57,7 +58,8 @@ def run(file: str, job_id: str, **kwargs):
 async def _run_local(f: str, **kwargs):
     with WorkflowFixtureScope() as scope:
         await create_config(scope=scope, **kwargs)
-        await execute(discovery.discover_workflow(Path(f).absolute()), scope)
+        result = await execute(discovery.discover_workflow(Path(f).absolute()), scope)
+        print(result)
 
 
 @apply_config_options

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -14,11 +14,11 @@ from . import runtime
 JOB_ID_ENV = "VIRTOOL_JOB_ID"
 
 
-@click.option("--uv-loop", is_flag=True, help="Use uvloop in place of standard asyncio event loop.")
+@click.option("--no-uv-loop", is_flag=True, help="Use standard asyncio event loop.")
 @click.group()
-def cli(uv_loop):
+def cli(no_uv_loop):
     """Command Line Interface for Virtool Workflows."""
-    if uv_loop:
+    if not no_uv_loop:
         uvloop.install()
 
 

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -49,7 +49,7 @@ async def _run(file: str, job_id: str, **kwargs):
 @click.argument("job_id", nargs=1, envvar=JOB_ID_ENV)
 @workflow_file_option
 @cli.command()
-async def run(file: str, job_id: str, **kwargs):
+def run(file: str, job_id: str, **kwargs):
     """Run a workflow and send updates to Virtool."""
     asyncio.run(_run(file, job_id, **kwargs))
 
@@ -63,7 +63,7 @@ async def _run_local(f: str, **kwargs):
 @apply_config_options
 @workflow_file_option
 @cli.command()
-async def run_local(f: str, **kwargs):
+def run_local(f: str, **kwargs):
     """Run a workflow locally, without runtime specific dependencies."""
     asyncio.run(_run_local(f, **kwargs))
 
@@ -78,7 +78,7 @@ async def _print_config(**kwargs):
 
 @apply_config_options
 @cli.command()
-async def print_config(**kwargs):
+def print_config(**kwargs):
     """Print the configuration which would be used with the given arguments."""
     asyncio.run(_print_config(**kwargs))
 

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -14,10 +14,12 @@ from . import runtime
 JOB_ID_ENV = "VIRTOOL_JOB_ID"
 
 
+@click.option("--uv-loop", is_flag=True, help="Use uvloop in place of standard asyncio event loop.")
 @click.group()
-def cli():
+def cli(uv_loop):
     """Command Line Interface for Virtool Workflows."""
-    uvloop.install()
+    if uv_loop:
+        uvloop.install()
 
 
 def workflow_file_option(func):
@@ -25,7 +27,7 @@ def workflow_file_option(func):
     return click.option(
         "-f",
         default="workflow.py",
-        type=click.Path(exists=True),
+        type=click.Path(),
         help="python module containing an instance of `virtool_workflow.Workflow`"
     )(func)
 
@@ -47,12 +49,12 @@ async def _run(file: str, job_id: str, **kwargs):
 
 
 @apply_config_options
-@click.argument("job_id", nargs=1, envvar=JOB_ID_ENV)
 @workflow_file_option
+@click.argument("job_id", nargs=1, envvar=JOB_ID_ENV)
 @cli.command()
-def run(file: str, job_id: str, **kwargs):
+def run(f: str, job_id: str, **kwargs):
     """Run a workflow and send updates to Virtool."""
-    asyncio.run(_run(file, job_id, **kwargs))
+    asyncio.run(_run(f, job_id, **kwargs))
 
 
 async def _run_local(f: str, **kwargs):

--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -41,11 +41,12 @@ def apply_config_options(func):
 
 async def _run(file: str, job_id: str, **kwargs):
     with WorkflowFixtureScope() as scope:
-        await create_config(scope, **kwargs)
+        config = await create_config(scope, **kwargs)
         workflow, _ = discovery.run_discovery(Path(file), Path(file).parent / "fixtures.py")
 
         result = await runtime.execute(job_id, workflow, scope)
-        print(result)
+        if config.dev_mode:
+            print(result)
 
 
 @apply_config_options
@@ -59,9 +60,11 @@ def run(f: str, job_id: str, **kwargs):
 
 async def _run_local(f: str, **kwargs):
     with WorkflowFixtureScope() as scope:
-        await create_config(scope=scope, **kwargs)
+        config = await create_config(scope=scope, **kwargs)
         result = await execute(discovery.discover_workflow(Path(f).absolute()), scope)
-        print(result)
+
+        if config.dev_mode:
+            print(result)
 
 
 @apply_config_options


### PR DESCRIPTION
- Use standard functions for CLI commands instead of coroutine functions.
- Print out workflow results when running `workflow run` or `workflow run-local`.
- Make uvloop optional
	- A NotImplementedError is being raised from uvloop when the `workflow run-local` command is executed.
	- I will raise an issue about it, but it's best to make it optional for now. 