### PR TITLE
Ensure Compatibility with uvloop

### DIFF
--- a/virtool_workflow_runtime/cli.py
+++ b/virtool_workflow_runtime/cli.py
@@ -10,6 +10,7 @@ from virtool_workflow.fixtures.scope import WorkflowFixtureScope
 from virtool_workflow_runtime.config.configuration import create_config, options
 from . import discovery
 from . import runtime
+from .uvloop_compatible_run import asyncio_run
 
 JOB_ID_ENV = "VIRTOOL_JOB_ID"
 
@@ -55,7 +56,7 @@ async def _run(file: str, job_id: str, **kwargs):
 @cli.command()
 def run(f: str, job_id: str, **kwargs):
     """Run a workflow and send updates to Virtool."""
-    asyncio.run(_run(f, job_id, **kwargs))
+    asyncio_run(_run(f, job_id, **kwargs))
 
 
 async def _run_local(f: str, **kwargs):
@@ -72,7 +73,7 @@ async def _run_local(f: str, **kwargs):
 @cli.command()
 def run_local(f: str, **kwargs):
     """Run a workflow locally, without runtime specific dependencies."""
-    asyncio.run(_run_local(f, **kwargs))
+    asyncio_run(_run_local(f, **kwargs))
 
 
 async def _print_config(**kwargs):
@@ -87,7 +88,7 @@ async def _print_config(**kwargs):
 @cli.command()
 def print_config(**kwargs):
     """Print the configuration which would be used with the given arguments."""
-    asyncio.run(_print_config(**kwargs))
+    asyncio_run(_print_config(**kwargs))
 
 
 @apply_config_options

--- a/virtool_workflow_runtime/uvloop_compatible_run.py
+++ b/virtool_workflow_runtime/uvloop_compatible_run.py
@@ -1,0 +1,61 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+
+def asyncio_run(coro, debug=None, n_threads=5):
+    """
+    Run a coroutine in a new asyncio event loop and ensure that all threads in the default executor have finished.
+
+    `uvloop` (latest release 0.14.0) is not compatible with Python 3.9 as it's event loop does not implement
+    `AbstractEventLoop.shutdown_default_executor()`. Using this function instead of `asyncio.run()` maintains
+    compatibility by setting the `default_executor` and ensuring it's threads join before the event loop is closed.
+
+    This function is adapted directly from the `asyncio.run()` source code, located at;
+
+    https://github.com/python/cpython/blob/master/Lib/asyncio/runners.py
+    """
+    if asyncio._get_running_loop() is not None:
+        raise RuntimeError(
+            "asyncio.run() cannot be called from a running event loop")
+
+    if not asyncio.iscoroutine(coro):
+        raise ValueError("a coroutine was expected, got {!r}".format(coro))
+
+    default_executor = ThreadPoolExecutor(n_threads)
+    loop = asyncio.new_event_loop()
+    loop.set_default_executor(default_executor)
+    try:
+        asyncio.set_event_loop(loop)
+        if debug is not None:
+            loop.set_debug(debug)
+        return loop.run_until_complete(coro)
+    finally:
+        try:
+            _cancel_all_tasks(loop)
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            default_executor.shutdown(wait=True)
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+
+def _cancel_all_tasks(loop):
+    to_cancel = asyncio.tasks.all_tasks(loop)
+    if not to_cancel:
+        return
+
+    for task in to_cancel:
+        task.cancel()
+
+    loop.run_until_complete(
+        asyncio.gather(*to_cancel, loop=loop, return_exceptions=True))
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler({
+                'message': 'unhandled exception during asyncio.run() shutdown',
+                'exception': task.exception(),
+                'task': task,
+            })


### PR DESCRIPTION
Resolves Issue #55


Re-implements `asyncio.run` to avoid using `shutdown_default_executor`. Instead set's the default executor and uses it's `shutdown` method when `loop.run_until_complete()` fails. 