### PR TITLE
Fix Imports from `workflow.py` Directory. 

### DIFF
--- a/tests/runtime/discovery/discoverable_workflow/discoverable_workflow_with_imports.py
+++ b/tests/runtime/discovery/discoverable_workflow/discoverable_workflow_with_imports.py
@@ -1,0 +1,12 @@
+import virtool_workflow
+
+from imported import foo, bar
+from package import module_in_package
+
+
+@virtool_workflow.step
+def _use_foo_and_bar(results):
+    results[foo] = foo
+    results[bar] = bar
+    results["variable"] = module_in_package.variable_in_module
+

--- a/tests/runtime/discovery/discoverable_workflow/imported.py
+++ b/tests/runtime/discovery/discoverable_workflow/imported.py
@@ -1,0 +1,3 @@
+
+foo = "foo"
+bar = "bar"

--- a/tests/runtime/discovery/discoverable_workflow/package/module_in_package.py
+++ b/tests/runtime/discovery/discoverable_workflow/package/module_in_package.py
@@ -1,0 +1,2 @@
+
+variable_in_module = None

--- a/tests/runtime/discovery/test_discovery.py
+++ b/tests/runtime/discovery/test_discovery.py
@@ -53,4 +53,4 @@ async def test_fixtures_from_autoload_py():
 
 
 
-
+    assert results["variable"] is None

--- a/tests/runtime/discovery/test_discovery.py
+++ b/tests/runtime/discovery/test_discovery.py
@@ -9,6 +9,8 @@ STATIC_TEST_FILE = cwd/"static_workflow.py"
 
 FIXTURE_TEST_FILE = cwd/"discoverable_fixtures.py"
 
+IMPORT_TEST_FILE = cwd/"discoverable_workflow/discoverable_workflow_with_imports.py"
+
 
 def test_discover_workflow():
     workflow = discovery.discover_workflow(TEST_FILE)
@@ -52,5 +54,14 @@ async def test_fixtures_from_autoload_py():
     assert "samples" in WorkflowFixture.types()
 
 
+async def test_import_workflow_with_other_imports():
+    workflow = discovery.discover_workflow(IMPORT_TEST_FILE)
 
+    results = {}
+    await workflow.steps[0](results)
+
+    assert results["foo"] == "foo"
+    assert results["bar"] == "bar"
     assert results["variable"] is None
+
+

--- a/virtool_workflow_runtime/discovery.py
+++ b/virtool_workflow_runtime/discovery.py
@@ -19,7 +19,10 @@ FixtureImportType = Iterable[
 
 def _import_module_from_file(module_name: str, path: Path) -> ModuleType:
     """
-    Import a module from a file
+    Import a module from a file.
+
+    The parent directory of `path` will also be added to `sys.path` prior to importing. This
+    ensures that modules and packages defined in that directory can be properly imported.
 
     :param module_name: The name of the python module.
     :param path: The :class:`pathlib.Path` of the python file

--- a/virtool_workflow_runtime/discovery.py
+++ b/virtool_workflow_runtime/discovery.py
@@ -1,4 +1,5 @@
 """Find workflows and fixtures from python modules."""
+import sys
 from importlib import import_module
 from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
@@ -24,8 +25,11 @@ def _import_module_from_file(module_name: str, path: Path) -> ModuleType:
     :param path: The :class:`pathlib.Path` of the python file
     :returns: The loaded python module.
     """
+    module_parent = str(path.parent)
+    sys.path.append(module_parent)
     spec = spec_from_file_location(module_name, path)
     module = spec.loader.load_module(module_from_spec(spec).__name__)
+    sys.path.remove(module_parent)
     return module
 
 
@@ -37,6 +41,7 @@ def discover_fixtures(module: Union[Path, ModuleType]) -> List[WorkflowFixture]:
     :return: A list of all #WorkflowFixture instances contained
         in the module
     """
+
     if isinstance(module, Path):
         module = _import_module_from_file(module.name.rstrip(module.suffix), module)
 
@@ -81,12 +86,14 @@ def discover_workflow(path: Path) -> Workflow:
     """
     module = _import_module_from_file(path.name.rstrip(path.suffix), path)
 
+    print([attr for attr in module.__dict__.items() if isinstance(attr[1], Workflow)])
     workflow = next((attr for attr in module.__dict__.values() if isinstance(attr, Workflow)), None)
 
     if not workflow:
-        workflow = collect(module)
+        return collect(module)
 
     return workflow
+
 
 
 def run_discovery(


### PR DESCRIPTION
Resolves #65

I explored several options including using python's `meta_path` hooks to modify how modules are imported. Ultimatley the simplest solution was to just add the path to `workflow.py`'s parent directory to `sys.path` and remove it once the `workflow.py` module is imported. 