### PR TITLE
Avoid direct database access in fixtures

### DIFF
--- a/tests/runtime/discovery/test_discovery.py
+++ b/tests/runtime/discovery/test_discovery.py
@@ -49,9 +49,8 @@ async def test_run_discovery():
 async def test_fixtures_from_autoload_py():
     discovery.run_discovery(FIXTURE_TEST_FILE)
 
-    assert "jobs" in WorkflowFixture.types()
-    assert "analyses" in WorkflowFixture.types()
-    assert "samples" in WorkflowFixture.types()
+    assert "data_path" in WorkflowFixture.types()
+    assert "temp_path" in WorkflowFixture.types()
 
 
 async def test_import_workflow_with_other_imports():

--- a/tests/subtractions/test_subtraction.py
+++ b/tests/subtractions/test_subtraction.py
@@ -22,12 +22,12 @@ subtraction_data_filenames = [
 ]
 
 
-async def _fetch_subtraction_document(id_: str):
+async def _fetch_subtraction_document(id_: str, _):
     return mock_subtractions[id_]
 
 
 async def test_subtractions(monkeypatch):
-    monkeypatch.setattr("virtool_workflow.db.db.fetch_subtraction_document", _fetch_subtraction_document)
+    monkeypatch.setattr("virtool_workflow.db.db.fetch_document_by_id", _fetch_subtraction_document)
 
     with context_directory("data/subtractions") as subtraction_data_path:
 

--- a/virtool_workflow/analysis/analysis_info.py
+++ b/virtool_workflow/analysis/analysis_info.py
@@ -12,7 +12,7 @@ from typing import Dict, Any
 from virtool_workflow import fixture, WorkflowFixture
 from virtool_workflow.analysis import utils
 from virtool_workflow.analysis.library_types import LibraryType
-from virtool_workflow_runtime.db.fixtures import Collection
+from virtool_workflow.db.db import fetch_document_by_id
 
 
 @dataclass(frozen=True)
@@ -28,15 +28,11 @@ class AnalysisInfo(WorkflowFixture, param_name="analysis_info"):
     @staticmethod
     async def __fixture__(
             job_document: Dict[str, Any],
-            samples: Collection,
-            analyses: Collection,
     ) -> "AnalysisInfo":
         """
         Fetch data related to an analysis job from the virtool database.
 
         :param job_document: The jobs document from the virtool database
-        :param samples: The samples collection from the virtool database
-        :param analyses: The analyses collection from the virtool database
         :return: A tuple containing the sample id, analysis id, reference id,
             index id, sample document, and analysis document.
         """
@@ -45,8 +41,8 @@ class AnalysisInfo(WorkflowFixture, param_name="analysis_info"):
         ref_id = job_document["ref_id"]
         index_id = job_document["index_id"]
 
-        sample = await samples.find_one(dict(_id=sample_id))
-        analysis_ = await analyses.find_one(dict(_id=analysis_id))
+        sample = await fetch_document_by_id(sample_id, "samples")
+        analysis_ = await fetch_document_by_id(analysis_id, "analyses")
 
         return AnalysisInfo(
             sample_id=sample_id,

--- a/virtool_workflow/analysis/cache.py
+++ b/virtool_workflow/analysis/cache.py
@@ -60,7 +60,8 @@ async def fetch_cache(
 
 async def create_cache_document(
         analysis_args: AnalysisArguments,
-        trimming_parameters: Dict[str, Any]
+        trimming_parameters: Dict[str, Any],
+        quality: Dict[str, Any]
 ) -> Dict[str, Any]:
     """
     Create a new cache document in the database.
@@ -69,9 +70,10 @@ async def create_cache_document(
 
     :param analysis_args: The AnalysisArguments fixture
     :param trimming_parameters: The trimming parameters (see virtool_workflow.analysis.trimming)
+    :param quality: The parsed fastqc output.
     :return: The cache document which was created.
     """
-    cache = await db.create_cache_document(analysis_args.sample_id, trimming_parameters, analysis_args.paired)
+    cache = await db.create_cache_document(analysis_args.sample_id, trimming_parameters, analysis_args.paired, quality)
 
     await db.update_analysis_with_cache_id(analysis_args.analysis_id, cache["id"])
 
@@ -80,40 +82,28 @@ async def create_cache_document(
 
 async def create_cache(
         fastq: Dict[str, Any],
-        database: VirtoolDatabase,
         analysis_args: AnalysisArguments,
         trimming_parameters: Dict[str, Any],
         trimming_output_path: Path,
         cache_path: Path,
 ):
-    """
-    Cache the trimmed reads and parsed fastqc data.
-
-    :param fastq: The parsed fastqc data produced by #virtool_workflow.analysis.fastqc.parse_fastqc
-        or the #virtool_workflow.analysis.read_paths.parsed_fastqc fixture.
-    """
-    cache = await create_cache_document(database, analysis_args, trimming_parameters)
-
-    await database["caches"].update_one({"_id": cache["id"]}, {"$set": {
-            "quality": fastq
-        }
-    })
+    """Cache the trimmed reads and parsed fastqc data."""
+    cache = await create_cache_document(analysis_args, trimming_parameters, quality=fastq)
 
     shutil.copytree(trimming_output_path, cache_path/cache["id"])
 
 
-async def delete_cache_if_not_ready(cache_id: str, caches: Collection, cache_path: Path):
+async def delete_cache_if_not_ready(cache_id: str, cache_path: Path):
     """
     Delete a cache if it is not ready.
 
     :param cache_id: The database id of the cache document.
-    :param caches: The caches database collection for Virtool.
     :param cache_path: The path to the cache entry which is to be removed.
     """
-    cache = await caches.find_one(cache_id, ["ready"])
+    cache = await db.find_document("caches", cache_id, ["ready"])
 
     if not cache["ready"]:
-        await caches.delete_one({"_id": cache_id})
+        await db.delete_cache(cache_id)
 
         try:
             shutil.rmtree(cache_path)
@@ -121,7 +111,7 @@ async def delete_cache_if_not_ready(cache_id: str, caches: Collection, cache_pat
             pass
 
 
-async def delete_analysis(analysis_id: str, analysis_path: Path, sample_id: str, database: VirtoolDatabase):
+async def delete_analysis(analysis_id: str, analysis_path: Path, sample_id: str):
     """
     Delete the analysis associated to `analysis_id`.
 
@@ -129,17 +119,15 @@ async def delete_analysis(analysis_id: str, analysis_path: Path, sample_id: str,
 
     :param analysis_id: The database id of the analysis document.
     :param analysis_path: The virtool analysis path.
-    :param analyses: The analyses database collection.
+    :param sample_id: The id of the sample associated with this analysis.
     """
 
-    analyses = database["analyses"]
-
-    await analyses.delete_one({"_id": analysis_id})
+    await db.delete_analysis(analysis_id)
 
     try:
         shutil.rmtree(analysis_path)
     except FileNotFoundError:
         pass
 
-    await virtool_core.samples.db.recalculate_workflow_tags(database, sample_id)
+    await db.recalculate_workflow_tags_for_sample(sample_id)
 

--- a/virtool_workflow/db/db.py
+++ b/virtool_workflow/db/db.py
@@ -1,4 +1,5 @@
 """Central module for database access. """
+import virtool_core.caches.db
 from virtool_workflow_runtime.db import VirtoolDatabase
 from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
 
@@ -9,8 +10,30 @@ _db = VirtoolDatabase(db_name(), db_connection_string())
 
 async def fetch_document_by_id(id_: str, collection_name: str) -> Optional[Dict[str, Any]]:
     """Fetch the document with the given ID from a specific Virtool database collection."""
-    document = _db[collection_name].find_one(dict(_id=id_))
+    document = await _db[collection_name].find_one(dict(_id=id_))
     if document:
         document["id"] = document["_id"]
     return document
+
+
+async def find_cache_document(query: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Find a cache document using the given query."""
+    return await _db["caches"].find_one(query)
+
+
+async def create_cache_document(sample_id: str, trimming_parameters: Dict[str, Any], paired: bool):
+    """Create a new cache document."""
+    return await virtool_core.caches.db.create(_db, sample_id, trimming_parameters, paired)
+
+
+async def update_analysis_with_cache_id(analysis_id: str, cache_id: str):
+    """Set the `id` field of the analysis document to the cache id."""
+    return await _db["analyses"].update_one({"_id": analysis_id}, {
+        "$set": {
+            "cache": {
+                "id": cache_id
+            }
+        }
+    })
+
 

--- a/virtool_workflow/db/db.py
+++ b/virtool_workflow/db/db.py
@@ -1,12 +1,17 @@
 """Central module for database access. """
+from virtool_core.db.bindings import BINDINGS
 import virtool_core.caches.db
+import virtool_core.db.core
 import virtool_core.samples.db
-from virtool_workflow_runtime.db import VirtoolDatabase
-from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
-
+from pathlib import Path
 from typing import Dict, Any, Optional
 
+from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
+from virtool_workflow_runtime.db import VirtoolDatabase
+
 _db = VirtoolDatabase(db_name(), db_connection_string())
+
+COLLECTION_NAMES = [binding.collection_name for binding in BINDINGS]
 
 
 async def fetch_document_by_id(id_: str, collection_name: str) -> Optional[Dict[str, Any]]:
@@ -20,6 +25,7 @@ async def fetch_document_by_id(id_: str, collection_name: str) -> Optional[Dict[
 async def find_document(collection_name: str, *args, **kwargs):
     """Find a document in a database collection based on the given query."""
     return await _db[collection_name].find_one(*args, **kwargs)
+
 
 async def find_cache_document(query: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Find a cache document using the given query."""
@@ -61,4 +67,9 @@ async def delete_analysis(analysis_id: str):
 async def recalculate_workflow_tags_for_sample(sample_id):
     """Recalculate the workflow tags for a sample."""
     return await virtool_core.samples.db.recalculate_workflow_tags(_db, sample_id)
+
+
+async def store_result(id_: str, result: Dict[str, Any], collection: str, file_results_location: Path):
+    """Store the result onto the document specified by `id_` in the collection specified by `collection`."""
+    await _db.store_result(id_, _db[collection], result, file_results_location)
 

--- a/virtool_workflow/db/db.py
+++ b/virtool_workflow/db/db.py
@@ -2,14 +2,15 @@
 from virtool_workflow_runtime.db import VirtoolDatabase
 from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
 
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 _db = VirtoolDatabase(db_name(), db_connection_string())
 
 
-async def fetch_subtraction_document(id_: str) -> Dict[str, Any]:
-    subtraction = await _db["subtractions"].find_one(dict(_id=id_))
+async def fetch_document_by_id(id_: str, collection_name: str) -> Optional[Dict[str, Any]]:
+    """Fetch the document with the given ID from a specific Virtool database collection."""
+    document = _db[collection_name].find_one(dict(_id=id_))
+    if document:
+        document["id"] = document["_id"]
+    return document
 
-    if subtraction:
-        subtraction["id"] = subtraction["_id"]
-        return subtraction

--- a/virtool_workflow/subtractions/subtraction.py
+++ b/virtool_workflow/subtractions/subtraction.py
@@ -65,4 +65,4 @@ async def subtractions(job_args: Dict[str, Any],
 
     await copy_paths({subtraction_data_path/id_: subtraction_path/id_ for id_ in ids}.items(), run_in_executor)
 
-    return [Subtraction.from_document(await db.fetch_subtraction_document(id_), subtraction_path) for id_ in ids]
+    return [Subtraction.from_document(await db.fetch_document_by_id(id_, "subtractions"), subtraction_path) for id_ in ids]


### PR DESCRIPTION
Create functions in `virtool_workflow.db` to replace any database actions perfomed from fixtures. 

Resolves #69