### PR TITLE
HMMs fixture

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -29,6 +29,17 @@ jobs:
 
       - name: Install tox
         run: pip install tox
+
+      - name: Install hmmer
+        run: |
+          wget http://eddylab.org/software/hmmer/hmmer-3.3.2.tar.gz
+          tar -xvf hmmer-3.3.2.tar.gz
+          cd hmmer-3.3.2
+          ./configure --prefix $GITHUB_WORKSPACE/hmmer
+          make
+          make install
+          cd ..
+          ln -s $GITHUB_WORKSPACE/hmmer/bin/hmm* /usr/local/bin
         
       - name: Run tox
         run: tox

--- a/tests/analysis/test_hmms.py
+++ b/tests/analysis/test_hmms.py
@@ -1,0 +1,41 @@
+import filecmp
+from concurrent.futures.thread import ThreadPoolExecutor
+from pathlib import Path
+from shutil import copy
+import sys
+
+from virtool_workflow.analysis.hmms import hmms
+from virtool_workflow.execution.run_in_executor import run_in_executor
+from virtool_workflow.execution.run_subprocess import run_subprocess
+
+FAKE_PROFILES_PATH = Path(sys.path[0]) / "tests/analysis/profiles.hmm"
+
+
+async def test_hmms(tmpdir):
+    temp_analysis_path = tmpdir.mkdir("temp")
+
+    data_path = tmpdir.mkdir("data")
+    hmms_path = data_path.mkdir("hmm")
+
+    copy(FAKE_PROFILES_PATH, hmms_path)
+
+    run_subprocess_ = run_subprocess()
+    run_in_executor_ = run_in_executor(ThreadPoolExecutor())
+
+    cluster_annotation_map = {
+        1: "foo",
+        3: "bar"
+    }
+
+    hmms_obj = await hmms(cluster_annotation_map, data_path, temp_analysis_path, run_in_executor_, run_subprocess_)
+
+    assert hmms_obj.cluster_annotation_map == cluster_annotation_map
+
+    assert filecmp.cmp(hmms_path / "profiles.hmm", hmms_obj.path)
+
+    expected_paths = {
+        temp_analysis_path / "hmms" / f"profiles.hmm{suffix}"
+        for suffix in ["", ".h3p", ".h3m", ".h3i", ".h3f"]
+    }
+
+    assert set((temp_analysis_path / "hmms").listdir()) == expected_paths

--- a/virtool_workflow/analysis/hmms.py
+++ b/virtool_workflow/analysis/hmms.py
@@ -1,0 +1,52 @@
+import shutil
+from dataclasses import dataclass
+from os import makedirs
+from pathlib import Path
+from typing import Dict
+
+from virtool_workflow import fixture
+from virtool_workflow.execution.run_in_executor import FunctionExecutor
+from virtool_workflow.execution.run_subprocess import RunSubprocess
+from virtool_workflow_runtime.db import VirtoolDatabase
+
+
+@dataclass
+class HMMs:
+    cluster_annotation_map: Dict[int, str]
+    path: Path
+
+
+@fixture
+async def cluster_annotation_map(database: VirtoolDatabase) -> Dict[int, str]:
+    cursor = database.hmm.find({}, ["cluster"])
+    return {int(document["cluster"]): document["_id"] async for document in cursor}
+
+
+@fixture
+async def hmms(
+    cluster_annotation_map: Dict[int, str],
+    data_path: Path,
+    temp_analysis_path: Path,
+    run_in_executor: FunctionExecutor,
+    run_subprocess: RunSubprocess,
+) -> HMMs:
+    """
+    A fixture for accessing HMM data.
+
+    The *.hmm file is copied from the data directory and `hmmpress` is run to create all the HMM files.
+
+    Returns a data object containing the path to the HMM profile file and a `dict` that maps HMM cluster numbers to
+    database IDs.
+
+    """
+    hmms_path = temp_analysis_path / "hmms"
+
+    await run_in_executor(makedirs, hmms_path)
+
+    await run_in_executor(shutil.copy, data_path / "hmm" / "profiles.hmm", hmms_path)
+
+    profiles_path = hmms_path / "profiles.hmm"
+
+    await run_subprocess(["hmmpress", str(profiles_path)])
+
+    return HMMs(cluster_annotation_map, profiles_path)


### PR DESCRIPTION
Add a fixture that:
- copies the `profiles.hmm` from the Virtool application data into the working path
- builds the HMM profiles using `hmmpress`
- builds a cluster-ID map from the database (allows lookup of database ID from cluster number used in hmmer)