### PR TITLE
Support Use of Fixtures Within Hook Callbacks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
     "tests.fixtures.workflow",
+    "tests.fixtures.scope",
     "tests.workflow_with_fixtures"
 ]

--- a/tests/execution/test_fixture_hooks.py
+++ b/tests/execution/test_fixture_hooks.py
@@ -1,0 +1,26 @@
+from virtool_workflow.execution.hooks.fixture_hooks import WorkflowFixtureHook
+from virtool_workflow.fixtures.scope import WorkflowFixtureScope
+
+test_hook = WorkflowFixtureHook("test_hook", [str, str], None)
+
+
+async def test_trigger():
+
+    hook_triggered = False
+
+    @test_hook
+    def use_test_hook(item1, item2, some_fixture):
+        nonlocal hook_triggered
+        hook_triggered = True
+        assert item1 == "item1"
+        assert item2 == "item2"
+        assert some_fixture == "some_fixture"
+
+    with WorkflowFixtureScope() as scope:
+        scope["some_fixture"] = "some_fixture"
+
+        await test_hook.trigger(scope, "item1", "item2")
+
+    assert hook_triggered
+
+

--- a/tests/execution/test_hooks.py
+++ b/tests/execution/test_hooks.py
@@ -7,18 +7,18 @@ async def example_hook_without_params():
     pass
 
 
-async def test_hook():
+async def test_hook(empty_scope):
 
     @example_hook_without_params.callback
     async def callback():
         callback.called = True
 
-    await example_hook_without_params.trigger()
+    await example_hook_without_params.trigger(empty_scope)
 
     assert callback.called
 
 
-async def test_temporary_callback():
+async def test_temporary_callback(empty_scope):
 
     @example_hook_without_params.callback(until=hooks.on_result)
     def temporary_callback():
@@ -26,7 +26,7 @@ async def test_temporary_callback():
 
     assert temporary_callback in example_hook_without_params.callbacks
 
-    await hooks.on_result.trigger(Workflow(), {})
+    await hooks.on_result.trigger(empty_scope)
 
     assert "remove_callback" not in [f.__name__ for f in example_hook_without_params.callbacks]
     assert temporary_callback not in example_hook_without_params.callbacks

--- a/tests/execution/test_hooks.py
+++ b/tests/execution/test_hooks.py
@@ -1,4 +1,4 @@
-from virtool_workflow import Workflow, hooks, hook
+from virtool_workflow import hooks, hook
 from virtool_workflow.execution.hooks.hooks import IncompatibleCallback
 
 
@@ -7,13 +7,13 @@ async def example_hook_without_params():
     pass
 
 
-async def test_hook(empty_scope):
+async def test_hook():
 
     @example_hook_without_params.callback
     async def callback():
         callback.called = True
 
-    await example_hook_without_params.trigger(empty_scope)
+    await example_hook_without_params.trigger()
 
     assert callback.called
 

--- a/tests/execution/test_run_subprocess.py
+++ b/tests/execution/test_run_subprocess.py
@@ -67,18 +67,18 @@ async def test_stderr_is_handled(bash):
     assert lines == [b"bash: /foo/bar: No such file or directory\n"]
 
 
-async def trigger_finish(test_workflow):
+async def trigger_finish(test_workflow, scope):
     try:
         await asyncio.sleep(1)
         raise Exception("Foo")
     except Exception as exc:
-        await hooks.on_failure.trigger(WorkflowError(exc, workflow=test_workflow, context=None))
+        await hooks.on_failure.trigger(scope, WorkflowError(exc, workflow=test_workflow, context=None))
 
 
-async def test_command_can_be_terminated(bash_sleep, test_workflow):
+async def test_command_can_be_terminated(bash_sleep, test_workflow, empty_scope):
     sh_path, txt_path = bash_sleep
 
-    t1 = asyncio.create_task(trigger_finish(test_workflow))
+    t1 = asyncio.create_task(trigger_finish(test_workflow, empty_scope))
     t2 = asyncio.create_task(run_subprocess(["bash", str(sh_path)]))
 
     await asyncio.gather(t1, t2)

--- a/tests/fixtures/scope.py
+++ b/tests/fixtures/scope.py
@@ -1,0 +1,8 @@
+import pytest
+from virtool_workflow import WorkflowFixtureScope
+
+
+@pytest.yield_fixture()
+def empty_scope():
+    with WorkflowFixtureScope() as scope:
+        yield scope

--- a/tests/runtime/db/test_db.py
+++ b/tests/runtime/db/test_db.py
@@ -1,27 +1,26 @@
 import sys
 from pathlib import Path
 
+from virtool_workflow import hooks, Workflow
+from virtool_workflow.fixtures.scope import WorkflowFixtureScope
 from virtool_workflow_runtime import runtime
+from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
 from virtool_workflow_runtime.db import VirtoolDatabase
 from virtool_workflow_runtime.discovery import discover_workflow
-from virtool_workflow.fixtures.scope import WorkflowFixtureScope
-from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
-from virtool_workflow import hooks
 
 EXAMPLE_WORKFLOW_PATH = Path(sys.path[0]).joinpath("tests/example_workflow.py")
 
 
-async def test_updates_sent_to_mongo():
-    with WorkflowFixtureScope() as fixtures:
-        name = await fixtures.instantiate(db_name)
-        conn = await fixtures.instantiate(db_connection_string)
+async def test_updates_sent_to_mongo(empty_scope):
+    name = db_name()
+    conn = db_connection_string()
 
-        db = VirtoolDatabase(name, conn)
-        await db._db.jobs.insert_one({"_id": "1"})
+    db = VirtoolDatabase(name, conn)
+    await db._db.jobs.insert_one({"_id": "1"})
 
     workflow = discover_workflow(EXAMPLE_WORKFLOW_PATH)
 
-    await runtime.execute("1", workflow)
+    await runtime.execute("1", workflow, empty_scope)
 
     document = await db._db.jobs.find_one({"_id": "1"})
 
@@ -31,7 +30,7 @@ async def test_updates_sent_to_mongo():
         assert update in updates
 
 
-async def test_results_stored_when_callback_set():
+async def test_results_stored_when_callback_set(empty_scope):
 
     with WorkflowFixtureScope() as fixtures:
         db: VirtoolDatabase = await fixtures.instantiate(VirtoolDatabase)
@@ -41,13 +40,15 @@ async def test_results_stored_when_callback_set():
 
         hooks.on_result(callback, once=True)
 
-        result = {}
+        empty_scope["results"] = {}
 
-        await hooks.on_result.trigger(None, result)
+        await hooks.on_result.trigger(empty_scope)
+
+        empty_scope["workflow"] = Workflow()
 
         document = await db["analyses"].find_one({"_id": "1"})
 
-        assert document["results"] == result
+        assert document["results"] == await empty_scope.get_or_instantiate("results")
         assert document["ready"]
 
 

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -3,9 +3,9 @@ from virtool_workflow_runtime.db import VirtoolDatabase
 from virtool_workflow_runtime.config.configuration import db_name, db_connection_string
 
 
-async def test_execute(test_workflow):
+async def test_execute(test_workflow, empty_scope):
     db = VirtoolDatabase(db_name(), db_connection_string())
 
     await db["jobs"].insert_one(dict(_id="1", args=dict()))
 
-    await runtime.execute("1", test_workflow)
+    await runtime.execute("1", test_workflow, empty_scope)

--- a/tests/runtime/test_runtime_hooks.py
+++ b/tests/runtime/test_runtime_hooks.py
@@ -3,7 +3,7 @@ from virtool_workflow_runtime import runtime
 from virtool_workflow import Workflow
 
 
-async def test_on_finish_triggered():
+async def test_on_finish_triggered(empty_scope):
 
     success_called = False
     finish_called = False
@@ -18,13 +18,13 @@ async def test_on_finish_triggered():
         nonlocal finish_called
         finish_called = True
 
-    await runtime.execute("1", Workflow())
+    await runtime.execute("1", Workflow(), empty_scope)
 
     assert success_called
     assert finish_called
 
 
-async def test_on_failure_triggered():
+async def test_on_failure_triggered(empty_scope):
 
     failure_called = False
 
@@ -42,26 +42,26 @@ async def test_on_failure_triggered():
         raise ValueError("test error")
 
     try:
-        await runtime.execute("1", workflow)
+        await runtime.execute("1", workflow, empty_scope)
     except Exception:
         pass
 
     assert failure_called
 
 
-async def test_on_failure_not_triggered_when_successful():
+async def test_on_failure_not_triggered_when_successful(empty_scope):
 
     @hooks.on_success
-    def success_callback(_, results):
+    def success_callback(results):
         results["SUCCESS"] = True
 
     @hooks.on_failure
-    def failure_callback(_):
+    def failure_callback():
         raise RuntimeError("Failure hook incorrectly triggered.")
 
     workflow = Workflow()
 
-    result = await runtime.execute("1", workflow)
+    result = await runtime.execute("1", workflow, empty_scope)
 
     assert result["SUCCESS"]
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -24,7 +24,7 @@ async def test_respond_errors(test_workflow):
     updates = []
 
     @hooks.on_update(until=hooks.on_workflow_finish)
-    async def receive_updates(_, update):
+    async def receive_updates(update):
         updates.append(update)
 
     await execute(test_workflow)

--- a/virtool_workflow/execution/hooks/README.md
+++ b/virtool_workflow/execution/hooks/README.md
@@ -1,0 +1,170 @@
+# Runtime Hooks
+
+Hooks are used to respond to various events in a workflow's lifecycle. Each hook maintains a list of callback
+functions which are triggered by the runtime and provided particular parameters. 
+
+For descriptions and example usage of the available runtime hooks see the [virtool_workflow.hooks](__init__.py) package.
+
+## The `Hook` Class
+
+`virtool_workflow.hooks.Hook` defines the following important methods;
+
+### `.__init__`
+
+Create a new Hook by providing;
+
+ 1. A *name* for the hook
+ 2. A `List[Type]` indicating the expected positional parameter types
+ 3. A `Type` indicating the expected return type
+ 
+ ```python
+from virtool_workflow.hooks import Hook
+
+on_example_event = Hook("on_example_event", [str], None)
+```
+
+The `on_example_event` hook defined above expects it's callback functions to accept a `str` as the first
+parameter and return `None`.
+
+### `.callback` or `.__call__`
+
+The `callback()` method (equivalent to `__call__`) is a decorator method that adds the
+provided `Callable` to the hook's set of callbacks. 
+
+Here is how it would be used to register a callback for the `on_example_event` hook.
+
+```python
+@on_example_event.callback
+def _callback(parameter: str):
+    ...
+```
+
+Equivalently; 
+
+```python
+@on_example_event
+def _callback(parameter: str):
+    ...
+```
+
+The callback function `_callback` can be either a regular function or a coroutine function. It can also opt to take
+no parameters if the parameters provided by the hook are not required. As such, the following will work just as well.
+
+```python
+@on_example_event
+async def _callback():
+    ...
+```
+
+#### The `once` and `until` Options
+
+`.callback()` also has the optional parameters `once` and `until`. The `once` flag ensures that the provided callback
+function is only invoked on the next time that the hook is triggered. In contrast the `until` option ensures that a callback
+will only be invoked until the next time a different `Hook` is triggered.  
+
+```python
+@on_example_event(once=True)
+def _callback():
+    ...
+```
+
+In the above example, `_callback` will only be invoked once, regardless of how many times `on_example_event` is triggered.
+
+```python
+on_some_other_event = Hook(...)
+
+@on_example_event(until=on_some_other_event)
+def _callback():
+    ...
+```
+
+Here `_callback` will be invoked each time the `on_example_event` hook is triggered, until the next time that 
+`on_some_other_event` is triggered.
+
+
+### `.trigger`
+
+The `trigger()` method invokes a hook's callback functions with the parameters provided to it. It expects to be
+passed positional parameters of the same *type* and *order* as was described when the `Hook` was created. 
+
+Here is how the `on_example_event` hook would be triggered.
+
+```python
+async def function_where_example_event_occurs():
+    # the event occurs and the required parameters are ready.
+    param = ...
+
+    results = await on_example_event.trigger(param)
+```
+
+`results` is a list containing the return values of each of the callback functions, In this case it's simply
+a `List[NoneType]`
+
+
+## Fixture Hooks
+
+Fixture hooks, defined using the `virtool_workflow.hooks.WorkflowFixtureHook` class, are similar to regular 
+hooks except that they inject workflow fixtures into their callback functions before invoking them. The 
+`virtool_workflow.WorkflowFixtureScope` instance used to inject the fixtures is the same one which is used
+for the workflow functions. This means that the fixture values (instances) will be shared between the hook
+callback functions and workflow functions.
+
+Fixture hooks can still have positional parameters in the same way regular hooks do. The difference being that 
+any additional parameters will identify fixtures to be injected. Also, in the same fashion as regular hooks, 
+the positional parameters can be ignored as well. 
+
+The important thing is that callback functions must either expect none of the positional parameters or all of them.
+Additionally they must declare the expected positional parameters before any "fixture parameters", and in the correct 
+order.
+
+### `.__init__`
+
+The `.__init__` method is the same as the `Hook` class.
+
+```python
+from virtool_workflow.hooks import WorkflowFixtureHook
+
+example_fixture_hook = WorkflowFixtureHook("example_fixture_hook", [str], str)
+```
+
+### `.callback`
+
+The `.callback` method works the same as in the `Hook` class, but does not perform any validation of the
+callbacks parameters. Since the function could take an arbitrary amount of fixture parameters it doesn't make
+sense to perform the validation. 
+
+Of course, any available fixtures can be accessed within the callback function.
+
+```python
+@example_fixtue_hook
+def _callback(param: str, some_fixture: Any):
+    ...
+```
+
+We can also omit the `param` positional parameter and just take fixture parameters.
+
+```python
+@example_fixtue_hook
+def _callback(some_fixture: Any, some_other_fixture: Any):
+    ...
+```
+
+### `.trigger`
+
+The `.trigger` method is the most changed from the `Hook` class. It expects a `WorkflowFixtureScope` as
+the first parameter, followed by the positional parameters expected by the hook. 
+
+```python
+from virtool_workflow import fixture, WorkflowFixtureScope
+
+@fixture
+def some_fixture():
+    return "some_value"
+
+@fixture
+def some_other_fixture():
+    return "some_other_value"
+
+with WorkflowFixtureScope() as scope:
+    await example_fixture_hook.trigger(scope, "positional_parameter") 
+```

--- a/virtool_workflow/execution/hooks/__init__.py
+++ b/virtool_workflow/execution/hooks/__init__.py
@@ -94,13 +94,13 @@ async def perform_on_success(workflow: Workflow):
 
 
 @on_workflow_failure
-async def _trigger_finish_from_failure(_, execution):
-    await on_workflow_finish.trigger(execution.workflow)
+async def _trigger_finish_from_failure(_, execution, scope):
+    await on_workflow_finish.trigger(scope, execution.workflow)
 
 
 @on_result
-async def _trigger_finish_from_success(workflow, _):
-    await on_workflow_finish.trigger(workflow)
+async def _trigger_finish_from_success(workflow, scope):
+    await on_workflow_finish.trigger(scope, workflow)
 
 
 on_success = WorkflowFixtureHook("on_success", parameters=[], return_type=None)

--- a/virtool_workflow/execution/hooks/__init__.py
+++ b/virtool_workflow/execution/hooks/__init__.py
@@ -94,13 +94,13 @@ async def perform_on_success(workflow: Workflow):
 
 
 @on_workflow_failure
-async def _trigger_finish_from_failure(_, execution, scope):
-    await on_workflow_finish.trigger(scope, execution.workflow)
+async def _trigger_finish_from_failure(_, scope):
+    await on_workflow_finish.trigger(scope)
 
 
 @on_result
-async def _trigger_finish_from_success(workflow, scope):
-    await on_workflow_finish.trigger(scope, workflow)
+async def _trigger_finish_from_success(scope):
+    await on_workflow_finish.trigger(scope)
 
 
 on_success = WorkflowFixtureHook("on_success", parameters=[], return_type=None)
@@ -164,9 +164,9 @@ async def on_cancelled(error: asyncio.CancelledError):
 
 
 @on_failure
-async def _trigger_on_cancelled(error: WorkflowError):
+async def _trigger_on_cancelled(error: WorkflowError, scope: WorkflowFixtureScope):
     if isinstance(error.cause, asyncio.CancelledError) or isinstance(error.cause, futures.CancelledError):
-        await on_cancelled.trigger(error.workflow, error.cause)
+        await on_cancelled.trigger(scope, error.cause)
 
 
 on_load_fixtures = WorkflowFixtureHook("on_load_fixtures", [WorkflowFixtureScope], return_type=None)

--- a/virtool_workflow/execution/hooks/__init__.py
+++ b/virtool_workflow/execution/hooks/__init__.py
@@ -1,20 +1,21 @@
 import asyncio
 from concurrent import futures
 from typing import Dict, Any
-from types import SimpleNamespace
 
-from virtool_workflow.execution.workflow_executor import WorkflowError, State, WorkflowExecution
-from virtool_workflow.fixtures.scope import WorkflowFixtureScope
-from virtool_workflow.workflow import Workflow
 from .hooks import Hook
+from .fixture_hooks import WorkflowFixtureHook
+from virtool_workflow.workflow import Workflow
+from virtool_workflow.fixtures.scope import WorkflowFixtureScope
+from virtool_workflow.execution.workflow_executor import WorkflowError, State, WorkflowExecution
 
-on_result = Hook("on_result", [Workflow, Dict[str, Any]], None)
+
+on_result = WorkflowFixtureHook("on_result", [], None)
 """
 Triggered when a workflow has completed and a result is available.
 
 ```python
 @on_result
-async def use_result(workflow: Workflow, result: Dict[str, Any]):
+async def use_result(workflow: Workflow, results: Dict[str, Any]):
     ...
 ```
 
@@ -23,7 +24,7 @@ such the result can be mutated within the callback and that change will be
 reflected in the final result. 
 """
 
-on_update = Hook("on_update", [WorkflowExecution, str], None)
+on_update = WorkflowFixtureHook("on_update", [str], None)
 """
 Triggered when an update is sent from a Workflow. 
 
@@ -37,7 +38,7 @@ async def use_updates(execution: WorkflowExecution, update: str):
 ```
 """
 
-on_workflow_step = Hook("on_workflow_step", [WorkflowExecution], None)
+on_workflow_step = WorkflowFixtureHook("on_workflow_step", [], None)
 """
 Triggered on each workflow step.
 
@@ -48,7 +49,7 @@ async def do_something_on_step(execution: WorkflowExecution):
 ```
 """
 
-on_state_change = Hook("on_state_change", [State, State], None)
+on_state_change = WorkflowFixtureHook("on_state_change", [State, State], None)
 """
 Triggered on a change of state during workflow execution.
 
@@ -59,7 +60,7 @@ async def do_something_on_state_change(old_state, new_state):
 ```
 """
 
-on_error = Hook("on_error", [WorkflowError], None)
+on_error = WorkflowFixtureHook("on_error", [WorkflowError], None)
 """
 Triggered when an exception occurs during a workflow.
 
@@ -70,7 +71,7 @@ async def perform_on_error(error: WorkflowError):
 ```
 """
 
-on_workflow_failure = Hook("on_workflow_finish", [Exception, WorkflowExecution], None)
+on_workflow_failure = WorkflowFixtureHook("on_workflow_finish", [Exception], None)
 """
 Triggered when a workflow fails to complete.
 
@@ -80,7 +81,7 @@ async def perform_on_failure(cause: Exception, execution: WorkflowExecution):
 ```
 """
 
-on_workflow_finish = Hook("on_workflow_finish", [Workflow], None)
+on_workflow_finish = WorkflowFixtureHook("on_workflow_finish", [], None)
 """
 Triggered when a workflow finishes, regardless of it's success.
 
@@ -102,7 +103,7 @@ async def _trigger_finish_from_success(workflow, _):
     await on_workflow_finish.trigger(workflow)
 
 
-on_success = Hook("on_success", parameters=[Workflow, Dict[str, Any]], return_type=None)
+on_success = WorkflowFixtureHook("on_success", parameters=[], return_type=None)
 """
 Triggered when a job completes successfully.
 
@@ -116,7 +117,7 @@ async def perform_on_success(workflow: Workflow, results: Dict[str, Any]):
 """
 
 
-on_failure = Hook("on_failure", parameters=[WorkflowError], return_type=None)
+on_failure = WorkflowFixtureHook("on_failure", parameters=[WorkflowError], return_type=None)
 """
 Triggered when a job fails to complete.
 
@@ -128,35 +129,35 @@ async def perform_on_failure(error: WorkflowError):
 """
 
 
-on_finish = Hook("on_finish", parameters=[Workflow], return_type=None)
+on_finish = WorkflowFixtureHook("on_finish", parameters=[], return_type=None)
 """
 Triggered when a job finishes, regardless of success or failure.
 
 ```python
 @on_finish
-async def perform_on_failure(error: Workflow):
+async def perform_on_finish(workflow: Workflow):
     ...
 ```
 """
 
 
 @on_success
-async def _trigger_on_finish_from_on_success(workflow: Workflow, _):
-    await on_finish.trigger(workflow)
+async def _trigger_on_finish_from_on_success(scope: WorkflowFixtureScope):
+    await on_finish.trigger(scope)
 
 
 @on_failure
-async def _trigger_on_finish_from_on_failure(error: WorkflowError):
-    await on_finish.trigger(error.workflow)
+async def _trigger_on_finish_from_on_failure(error: WorkflowError, scope: WorkflowFixtureScope):
+    await on_finish.trigger(scope, error.workflow)
 
 
-on_cancelled = Hook("on_cancelled", [Workflow, asyncio.CancelledError], None)
+on_cancelled = WorkflowFixtureHook("on_cancelled", [asyncio.CancelledError], None)
 """
 Triggered when a job is cancelled.
 
 ```python
 @on_cancelled
-async def on_cancelled(workflow: Workflow, error: asyncio.CancelledError):
+async def on_cancelled(error: asyncio.CancelledError):
     ...
 ```
 """
@@ -168,10 +169,10 @@ async def _trigger_on_cancelled(error: WorkflowError):
         await on_cancelled.trigger(error.workflow, error.cause)
 
 
-on_load_fixtures = Hook("on_load_fixtures", [WorkflowFixtureScope], return_type=None)
+on_load_fixtures = WorkflowFixtureHook("on_load_fixtures", [WorkflowFixtureScope], return_type=None)
 """
-Triggered after runtime fixtures have been added to the #WorkflowFixtureScope, but 
-before the workflow is executed. 
+Triggered after runtime fixtures have been added to the #WorkflowFixtureScope, but
+before the workflow is executed.
 
 Enables modification or injection of specific fixtures before a workflow is executed.
 
@@ -181,20 +182,6 @@ async def change_fixture_values(fixtures: WorkflowFixtureScope):
     fixtures["some_fixture"] = SOME_VALUE
     await fixtures.get_or_instantiate("name_of_some_other_fixture)
     ...
-```
-"""
-
-on_load_config = Hook("on_load_config", [SimpleNamespace], None)
-"""
-Triggered after the config is loaded from the CLI arguments and environment variables. A SimpleNamespace object
-is provided which has an attribute (sharing the same name as the fixture) for each configuration fixture in
-`virtool_workflow_runtime.config.configuration`. 
-
-```python
-@on_load_config
-def use_config(config: SimpleNamespace):
-    if config.dev_mode:
-        ...
 ```
 """
 

--- a/virtool_workflow/execution/hooks/__init__.py
+++ b/virtool_workflow/execution/hooks/__init__.py
@@ -1,13 +1,12 @@
-import asyncio
 from concurrent import futures
-from typing import Dict, Any
 
+import asyncio
+from types import SimpleNamespace
+
+from virtool_workflow.execution.workflow_executor import WorkflowError, State
+from virtool_workflow.fixtures.scope import WorkflowFixtureScope
 from .hooks import Hook
 from .fixture_hooks import WorkflowFixtureHook
-from virtool_workflow.workflow import Workflow
-from virtool_workflow.fixtures.scope import WorkflowFixtureScope
-from virtool_workflow.execution.workflow_executor import WorkflowError, State, WorkflowExecution
-
 
 on_result = WorkflowFixtureHook("on_result", [], None)
 """
@@ -185,3 +184,15 @@ async def change_fixture_values(fixtures: WorkflowFixtureScope):
 ```
 """
 
+on_load_config = Hook("on_load_config", [SimpleNamespace], None)
+"""
+Triggered after the config is loaded from the CLI arguments and environment variables. A SimpleNamespace object
+is provided which has an attribute (sharing the same name as the fixture) for each configuration fixture in
+`virtool_workflow_runtime.config.configuration`. 
+```python
+@on_load_config
+def use_config(config: SimpleNamespace):
+    if config.dev_mode:
+        ...
+```
+"""

--- a/virtool_workflow/execution/hooks/fixture_hooks.py
+++ b/virtool_workflow/execution/hooks/fixture_hooks.py
@@ -1,0 +1,31 @@
+from typing import List, Any, Type, Optional, Callable
+from inspect import signature
+
+from virtool_workflow import utils
+from virtool_workflow.execution.hooks import Hook
+from virtool_workflow.fixtures.scope import WorkflowFixtureScope
+
+
+class HookRequirementNotProvided(Exception):
+    def __init__(self, hook: Hook, name: str, type: Optional[Type]):
+        super().__init__(f"The {hook.name} hook's `.trigger` method requires keyword argument {name}: {type}")
+
+
+class WorkflowFixtureHook(Hook):
+    """A Hook which binds fixtures to it's callback functions before invoking them."""
+
+    def _callback(self, callback_: Callable):
+        """Register a callback function, skipping parameter validation"""
+        callback_ = utils.coerce_to_coroutine_function(callback_)
+        self.callbacks.append(callback_)
+        return callback_
+
+    async def trigger(self, scope: WorkflowFixtureScope, *args, **kwargs) -> List[Any]:
+        """Bind fixtures from `scope` to each callback function and invoke them."""
+        _callbacks = [await scope.bind(callback, strict=False) for callback in self.callbacks]
+        _callbacks = [utils.coerce_coroutine_function_to_accept_any_parameters(callback)
+                      if len(signature(callback).parameters) == 0 else callback
+                      for callback in _callbacks]
+
+        return [await callback(*args, **kwargs) for callback in _callbacks]
+

--- a/virtool_workflow/execution/hooks/hooks.py
+++ b/virtool_workflow/execution/hooks/hooks.py
@@ -153,7 +153,6 @@ class Hook:
 
             @hook_._callback
             def remove_callback():
-                print(f"removing {callback_}")
                 self.callbacks.remove(callback_)
                 hook_.callbacks.remove(remove_callback)
 

--- a/virtool_workflow/fixtures/scope.py
+++ b/virtool_workflow/fixtures/scope.py
@@ -147,7 +147,7 @@ class WorkflowFixtureScope(AbstractContextManager):
         for name in names:
             self.__setitem__(name, instance)
 
-    async def bind(self, func: Callable[..., Any]) -> Callable[[], Any]:
+    async def bind(self, func: Callable[..., Any], strict: bool = True) -> Callable[[], Any]:
         """
         Bind fixtures to the parameters of a function.
 
@@ -156,18 +156,21 @@ class WorkflowFixtureScope(AbstractContextManager):
         arguments given are added as keyword arguments to the function.
 
         :param func: The function requiring workflow fixtures to be bound
+        :param strict: A flag indicating that all parameters must be bound to a fixture, defaults to True
         :return: A new function with it's arguments appropriately bound
         :raise WorkflowFixtureNotAvailable: When `func` requires an argument
             which cannot be bound due to no fixture of it's name being available.
         """
         sig = signature(func)
 
-        try:
-            fixtures = {param: await self.get_or_instantiate(param)
-                        for param in sig.parameters}
-        except KeyError as key_error:
-            missing_param = key_error.args[0]
-            raise WorkflowFixtureNotAvailable(param_name=missing_param, signature=sig, func=func)
+        fixtures = {}
+        for param in sig.parameters:
+            try:
+                fixtures[param] = await self.get_or_instantiate(param)
+            except KeyError as key_error:
+                if strict:
+                    missing_param = key_error.args[0]
+                    raise WorkflowFixtureNotAvailable(param_name=missing_param, signature=sig, func=func)
 
         if iscoroutinefunction(func):
             @wraps(func)

--- a/virtool_workflow_runtime/db/db.py
+++ b/virtool_workflow_runtime/db/db.py
@@ -109,7 +109,7 @@ class VirtoolDatabase(WorkflowFixture, param_name="database"):
 
     @staticmethod
     def store_result_callback(id_: str, collection: Collection, file_results_location: Path):
-        async def _store_results(_, results):
+        async def _store_results(results):
             return await VirtoolDatabase.store_result(id_, collection, results, file_results_location)
 
         return _store_results

--- a/virtool_workflow_runtime/runtime.py
+++ b/virtool_workflow_runtime/runtime.py
@@ -40,10 +40,10 @@ async def execute(
     """
 
     logger.debug("Creating a new WorkflowExecution")
-    executor = WorkflowExecution(workflow, fixtures)
+    executor = WorkflowExecution(workflow, scope)
     try:
-        result = await _execute(job_id, workflow, fixtures, executor)
-        await hooks.on_success.trigger(workflow, result)
+        result = await _execute(job_id, workflow, scope, executor)
+        await hooks.on_success.trigger(scope)
 
         return result
     except Exception as e:


### PR DESCRIPTION
Adds support for using fixtures from within runtime hooks. 

For example, we can now access any partial results within a callback for the `on_failure` hook.

```python
from virtool_workflow import hooks, step

@step
def produce_some_result(results):
	results["some_result"] = "result"


@hooks.on_failure
def check_partial_results(results):
	results["some_result"] # "result"

```

All hooks support fixtures with the exception of `on_load_config` which is triggered before the 
`WorkflowFixtureScope` for the workflow is created.