### PR TITLE
Use Temporary Directory for `data_path` During Tests.

### DIFF
--- a/tests/analysis/test_analysis_fixture.py
+++ b/tests/analysis/test_analysis_fixture.py
@@ -28,7 +28,7 @@ async def test_upload_file(runtime: TestRuntime):
         "foo",
         "A test file",
         test_file,
-        "reads",
+        "fasta",
     )
 
     async def use_analysis_fixture(analysis: Analysis, analysis_path: Path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from virtool_workflow.storage.paths import data_path, context_directory
+
 pytest_plugins = [
     "tests.fixtures.workflow",
     "tests.fixtures.scope",
@@ -5,3 +7,5 @@ pytest_plugins = [
     "tests.workflow_with_fixtures",
     "virtool_workflow_runtime.test_utils"
 ]
+
+

--- a/virtool_workflow_runtime/test_utils.py
+++ b/virtool_workflow_runtime/test_utils.py
@@ -6,6 +6,7 @@ import inspect
 from virtool_workflow import WorkflowExecution, WorkflowFixtureScope, Workflow
 from virtool_workflow_runtime.abc.runtime import AbstractRuntime
 from virtool_workflow_runtime.runtime import runtime_scope
+from virtool_workflow.storage.paths import data_path, context_directory
 
 
 class TestRuntime(AbstractRuntime):
@@ -29,6 +30,12 @@ class TestRuntime(AbstractRuntime):
 
     @property
     def scope(self) -> WorkflowFixtureScope:
+        def temp_data_path(data_path_str):
+            with context_directory(data_path_str) as path:
+                yield path
+
+        # Use a temporary directory for the data_path during tests.
+        data_path.__fixture__ = temp_data_path
         return runtime_scope
 
     @property


### PR DESCRIPTION
Prevents unwanted files and directories from being left after the tests have run. 