### PR TITLE
Build and Push `virtool/workflow` to Docker Hub on Release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: virtool/workflow-${{ steps.tags.outputs.TAG }}
+          tags: virtool/workflow:${{ steps.tags.outputs.TAG }}
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,11 +11,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
+          context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          file: $GITHUB_WORKSPACE/docker/Dockerfile
           repository: virtool/workflow
           tag_with_ref: true
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          file: ${{GITHUB_WORKSPACE}}/docker/Dockerfile
+          file: ${{ GITHUB_WORKSPACE }}/docker/Dockerfile
           repository: virtool/workflow
           tag_with_ref: true
 
@@ -24,4 +24,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: virtool/workflow
+          readme-filepath: ${{ GITHUB_WORKSPACE }}/docker/README.md
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,28 +1,27 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Release Workflow Docker Image
 
-# Controls when the action will run. 
-on: [release, workflow_dispatch]
+on: [ release, workflow_dispatch ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  push_to_dockerhub:
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          file: ${{GITHUB_WORKSPACE}}/docker/Dockerfile
+          repository: virtool/workflow
+          tag_with_ref: true
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Update README on Docker Hub
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: virtool/workflow
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,7 +2,7 @@ name: Release Workflow Docker Image
 
 on:
   release:
-    types: [ published ]
+    types: [ created ]
 
 jobs:
   push_to_dockerhub:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: virtool/workflow-{{ GITHUB_REF }}
+          tags: virtool/workflow-${{ GITHUB_REF }}
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Release Workflow Docker Image
+
+# Controls when the action will run. 
+on: [release, workflow_dispatch]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,6 +16,18 @@ jobs:
         id: tags
         run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
 
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
@@ -23,9 +35,6 @@ jobs:
           push: true
           tags: virtool/workflow:${{ steps.tags.outputs.TAG }}
           context: ./docker
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: virtool/workflow
 
       - name: Update README on Docker Hub
         uses: peter-evans/dockerhub-description@v2

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Update README on Docker Hub
         uses: peter-evans/dockerhub-description@v2
         with:
+          push: true
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: virtool/workflow

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,11 +12,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Get Tag
+        id: tags
+        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+
+
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "virtool/workflow-${GITHUB_REF##*/}"
+          tags: virtool/workflow-{{ steps.tags.outputs.TAG }}
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,12 +9,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Push to Docker Hub
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          file: ${{ GITHUB_WORKSPACE }}/docker/Dockerfile
+          file: $GITHUB_WORKSPACE/docker/Dockerfile
           repository: virtool/workflow
           tag_with_ref: true
 
@@ -24,5 +25,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: virtool/workflow
-          readme-filepath: ${{ GITHUB_WORKSPACE }}/docker/README.md
+          readme-filepath: $GITHUB_WORKSPACE/docker/README.md
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:
+          push: true
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -22,7 +23,6 @@ jobs:
       - name: Update README on Docker Hub
         uses: peter-evans/dockerhub-description@v2
         with:
-          push: true
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: virtool/workflow

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: virtool/workflow-${{ GITHUB_REF }}
+          tags: "virtool/workflow-${GITHUB_REF##*/}"
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: virtool/workflow-{{ steps.tags.outputs.TAG }}
+          tags: virtool/workflow-${{ steps.tags.outputs.TAG }}
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,8 @@
 name: Release Workflow Docker Image
 
-on: [ release, workflow_dispatch ]
+on:
+  release:
+    types: [ published ]
 
 jobs:
   push_to_dockerhub:
@@ -14,11 +16,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          tags: virtool/workflow-{{ GITHUB_REF }}
           context: ./docker
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: virtool/workflow
-          tag_with_ref: true
 
       - name: Update README on Docker Hub
         uses: peter-evans/dockerhub-description@v2

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,5 +25,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: virtool/workflow
-          readme-filepath: $GITHUB_WORKSPACE/docker/README.md
+          readme-filepath: ./docker/README.md
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,8 +43,7 @@ RUN wget https://zlib.net/pigz/pigz-2.6.tar.gz && \
     cd pigz-2.6 && \
     make
 
-
-
+# virtool-workflow dependencies
 FROM python:3.9 as pip_install
 ARG VIRTOOL_WORKFLOW_PIP_PACKAGE="virtool-workflow"
 RUN pip install --user $VIRTOOL_WORKFLOW_PIP_PACKAGE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,7 @@
 FROM debian:buster as debian
 WORKDIR /build
 RUN apt-get update && apt-get install -y build-essential wget bioperl
-RUN wget https://bitbucket.org/wenchen_aafc/aodp_v2.0_release/raw/5fcd5d2dfde61cd87ad3c63b8c92babd281fc0dc/aodp-2.5.0.1.tar.gz && \
-    tar -xvf aodp-2.5.0.1.tar.gz && \
-    cd aodp-2.5.0.1 && \
-    ./configure && \
-    make && \
-    mv b/aodp /build && \
-    wget http://eddylab.org/software/hmmer/hmmer-3.2.1.tar.gz && \
+RUN wget http://eddylab.org/software/hmmer/hmmer-3.2.1.tar.gz && \
     tar -xf hmmer-3.2.1.tar.gz && \
     cd hmmer-3.2.1 && \
     ./configure --prefix /build/hmmer && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,25 @@
+# HMMER and Skewer
+FROM debian:buster as debian
+WORKDIR /build
+RUN apt-get update && apt-get install -y build-essential wget bioperl
+RUN wget https://bitbucket.org/wenchen_aafc/aodp_v2.0_release/raw/5fcd5d2dfde61cd87ad3c63b8c92babd281fc0dc/aodp-2.5.0.1.tar.gz && \
+    tar -xvf aodp-2.5.0.1.tar.gz && \
+    cd aodp-2.5.0.1 && \
+    ./configure && \
+    make && \
+    mv b/aodp /build && \
+    wget http://eddylab.org/software/hmmer/hmmer-3.2.1.tar.gz && \
+    tar -xf hmmer-3.2.1.tar.gz && \
+    cd hmmer-3.2.1 && \
+    ./configure --prefix /build/hmmer && \
+    make && \
+    make install && \
+    wget https://github.com/relipmoc/skewer/archive/0.2.2.tar.gz && \
+    tar -xf 0.2.2.tar.gz && \
+    cd skewer-0.2.2 && \
+    make && \
+    mv skewer /build
+
 # Bowtie2
 FROM alpine:latest as bowtie
 WORKDIR /build
@@ -6,13 +28,22 @@ RUN wget https://github.com/BenLangmead/bowtie2/releases/download/v2.3.2/bowtie2
     mkdir bowtie2 && \
     cp bowtie2-2.3.2-legacy/bowtie2* bowtie2
 
+# FastQC
+FROM alpine:latest as fastqc
+WORKDIR /build
+RUN wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip && \
+    unzip fastqc_v0.11.5.zip
+
 FROM python:3.9 as pip_install
-ARG VIRTOOL_WORKFLOW_PIP_PACKAGE="virtool-workflow==0.1.0"
+ARG VIRTOOL_WORKFLOW_PIP_PACKAGE="virtool-workflow==0.4.0"
 RUN pip install --user $VIRTOOL_WORKFLOW_PIP_PACKAGE
 
 FROM python:3.9-slim as main
 COPY --from=pip_install /root/.local /root/.local
 COPY --from=bowtie /build/bowtie2/* /usr/local/bin/
+COPY --from=debian /build/hmmer /opt/hmmer
+COPY --from=debian /build/skewer /usr/local/bin/
+COPY --from=fastqc /build/FastQC /opt/fastqc
 ENV PATH $PATH:/root/.local/bin
 ENTRYPOINT ["workflow", "run"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,17 @@ WORKDIR /build
 RUN wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip && \
     unzip fastqc_v0.11.5.zip
 
+# Pigz
+FROM debian:buster as pigz
+WORKDIR /build
+RUN apt-get update && apt-get install -y make gcc zlib1g-dev wget
+RUN wget https://zlib.net/pigz/pigz-2.6.tar.gz && \
+    tar -xzvf pigz-2.6.tar.gz && \
+    cd pigz-2.6 && \
+    make
+
+
+
 FROM python:3.9 as pip_install
 ARG VIRTOOL_WORKFLOW_PIP_PACKAGE="virtool-workflow==0.4.0"
 RUN pip install --user $VIRTOOL_WORKFLOW_PIP_PACKAGE
@@ -44,9 +55,9 @@ COPY --from=bowtie /build/bowtie2/* /usr/local/bin/
 COPY --from=debian /build/hmmer /opt/hmmer
 COPY --from=debian /build/skewer /usr/local/bin/
 COPY --from=fastqc /build/FastQC /opt/fastqc
+COPY --from=pigz /build/pigz-2.6/pigz /usr/local/bin/pigz
 ENV PATH $PATH:/root/.local/bin
 
-RUN apt-get install -y pigz
 ENTRYPOINT ["workflow", "run"]
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ RUN wget https://zlib.net/pigz/pigz-2.6.tar.gz && \
 
 
 FROM python:3.9 as pip_install
-ARG VIRTOOL_WORKFLOW_PIP_PACKAGE="virtool-workflow==0.4.0"
+ARG VIRTOOL_WORKFLOW_PIP_PACKAGE="virtool-workflow"
 RUN pip install --user $VIRTOOL_WORKFLOW_PIP_PACKAGE
 
 FROM python:3.9-slim as main

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=debian /build/hmmer /opt/hmmer
 COPY --from=debian /build/skewer /usr/local/bin/
 COPY --from=fastqc /build/FastQC /opt/fastqc
 ENV PATH $PATH:/root/.local/bin
+
+RUN apt-get install -y pigz
 ENTRYPOINT ["workflow", "run"]
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-t # The Virtool Workflow Base Image
+# The Virtool Workflow Base Image
 
 ## Containerizing Standalone Workflows
 
@@ -10,17 +10,17 @@ COPY my_fixtures.py fixtures.py
 ```
 
 The `virtool_workflow_standalone` Dockerfile sets the ENTRYPOINT command to;
+
 ```
 workflow run
 ```
 
-As such any CLI arguments (see `workflow run --help`) can be passed along when
-running the container. 
+As such any CLI arguments (see `workflow run --help`) can be passed along when running the container.
 
 ## Install Additional Dependencies Using Multi-stage Builds
 
-Docker's [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) allow you to build a 
-piece of software in one image and copy it's binaries to your desired image. 
+Docker's [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) allow you to build a
+piece of software in one image and copy it's binaries to your desired image.
 
 For example here is how you would install `fastqc` into the `virtool_workflow_standalone` image.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,9 @@
-# The Virtool Workflow Base Image
+# A Base Image For Virtool Workflows
 
-## Containerizing Standalone Workflows
+## Usage
 
 ```dockerfile
-FROM virtool_workflow_standalone
+FROM virtool/workflow
 
 COPY my_workflow.py workflow.py
 COPY my_fixtures.py fixtures.py
@@ -16,25 +16,4 @@ workflow run
 ```
 
 As such any CLI arguments (see `workflow run --help`) can be passed along when running the container.
-
-## Install Additional Dependencies Using Multi-stage Builds
-
-Docker's [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) allow you to build a
-piece of software in one image and copy it's binaries to your desired image.
-
-For example here is how you would install `fastqc` into the `virtool_workflow_standalone` image.
-
-```dockerfile
-FROM alpine:latest as fastqc
-
-WORKDIR /build
-RUN wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip && \
-    unzip fastqc_v0.11.5.zip
-
-FROM virtool_workflow_standalone
-
-COPY --from=fastqc build/FastQC /opt/fastqc
-
-COPY my_workflow.py workflow.py
-```
 

--- a/virtool_workflow/api/indexes.py
+++ b/virtool_workflow/api/indexes.py
@@ -53,7 +53,7 @@ class IndexProvider(AbstractIndexProvider):
                     await _fetch_reference(self._ref_id, self.http, self.jobs_api_url),
                 )
 
-    async def upload(self, path: Path, format: VirtoolFileFormat = "fasta") -> VirtoolFile:
+    async def upload(self, path: Path, format_: VirtoolFileFormat = "fasta") -> VirtoolFile:
         """
         Upload a file associated with the current Index.
 
@@ -69,12 +69,12 @@ class IndexProvider(AbstractIndexProvider):
             - reference.rev.2.bt2
 
         :param path: The path to the file.
-        :param format: The format of the file.
+        :param format_: The format of the file.
         :return: A :class:`VirtoolFile` object.
         """
         return await upload_file_via_post(self.http,
                                           f"{self.jobs_api_url}/indexes/{self._index_id}/files",
-                                          path, format)
+                                          path, format_)
 
     async def download(self, target_path: Path, *names) -> Path:
         """Download files associated with the current index."""


### PR DESCRIPTION
- Updates the workflow base docker file to include the required external tools
- Adds a github action which will build and push the `virtool/workflow` container to Docker Hub on release
- The description of the `virtool/workflow` image on docker hub will be updated to the contents of the /docker/README.md file

In order for the github action to work the following github secrets must be set.

- DOCKER_USERNAME
- DOCKER_PASSWORD