### PR TITLE
Get Job Fixture Working In Integration Tests

### DIFF
--- a/integration_test_workflow/.env
+++ b/integration_test_workflow/.env
@@ -1,0 +1,2 @@
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_FILE=docker-compose.test.yml:docker-compose.dev.yml

--- a/integration_test_workflow/README.md
+++ b/integration_test_workflow/README.md
@@ -30,15 +30,23 @@ The `build.sh` script accepts some options to allow use of forks.
 ```text
     Build the docker images for the 'virtool_workflow' integration tests.
 
-    Syntax: ./build.sh [--virtool-repo|--virtool-workflow-repo]
+    Syntax: ./build.sh [--virtool-repo|--virtool-workflow-repo|--local-virtool-workflow|--local-virtool]
     Options:
     --virtool-repo             The URL of the virtool github repo (to use your fork).
     --virtool-branch           The name of the branch to pull from the virtool repo.
     --virtool-workflow-repo    The URL of the virtool-workflow github repo (to use your fork).
+    --local-virtool-workflow   The path to the local virtool-workflow directory.
+    --local-virtool            The path to the local virtool directory.
 ```
 
 To use a specific branch of `virtool_workflow` you can give;
 
 ```shell script
 ./build.sh --virtool-workflow-repo pip install git+https://github.com/{username}/{repo_name}.git@{branch_name}
+```
+
+To use local files instead of pulling from github use;
+
+```shell script
+./build.sh --local-virtool "/path/to/virtool" --local-virtool-workflow "/path/to/local/virtool-workflow"
 ```

--- a/integration_test_workflow/build.sh
+++ b/integration_test_workflow/build.sh
@@ -66,7 +66,7 @@ test_dockerfile=$(realpath workflow/Dockerfile)
 workflow_latest_dockerfile=$(realpath latest-workflow-Dockerfile)
 
 _print "Building 'virtool/workflow' image with the latest version of 'virtool_workflow'..."
-docker build -t virtool/workflow -f $workflow_latest_dockerfile --build-arg "VIRTOOL_WORKFLOW_REPO=$virtool_workflow_repo" .
+docker build -t virtool/workflow -f $workflow_latest_dockerfile --build-arg "VIRTOOL_WORKFLOW_REPO=$virtool_workflow_repo" --no-cache .
 
 _print "Building 'virtool/integration_test_workflow'..."
 docker build -t virtool/integration_test_workflow -f $test_dockerfile workflow

--- a/integration_test_workflow/build.sh
+++ b/integration_test_workflow/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 format='\e[1;34m%-6s\e[m'
 
 _print_one_line(){

--- a/integration_test_workflow/build.sh
+++ b/integration_test_workflow/build.sh
@@ -18,11 +18,13 @@ _print() {
 _help() {
     echo "Build the docker images for the 'virtool_workflow' integration tests."
     echo
-    echo "Syntax: ./build.sh [--virtool-repo|--virtool-workflow-repo]"
+    echo "Syntax: ./build.sh [--virtool-repo|--virtool-workflow-repo|--local-virtool-workflow|--local-virtool]"
     echo "Options:"
     echo "--virtool-repo             The URL of the virtool github repo (to use your fork)."
     echo "--virtool-branch           The name of the branch to pull from the virtool repo." 
     echo "--virtool-workflow-repo    The URL of the virtool-workflow github repo (to use your fork)."
+    echo "--local-virtool-workflow   The path to the local virtool-workflow directory."
+    echo "--local-virtool            The path to the local virtool directory."
     echo
 }
 
@@ -47,6 +49,16 @@ do
             shift 
             shift
         ;;
+        --local-virtool-workflow)
+            LOCAL_VIRTOOL_WORKFLOW_PATH="$2"
+            shift 
+            shift
+        ;;
+        --local-virtool)
+            LOCAL_VIRTOOL_PATH="$2"
+            shift 
+            shift
+        ;;
         --help)
             _help
             exit
@@ -64,27 +76,42 @@ cwd=$(pwd)
 dockerfile=$(realpath api-server-Dockerfile)
 test_dockerfile=$(realpath workflow/Dockerfile)
 workflow_latest_dockerfile=$(realpath latest-workflow-Dockerfile)
+workflow_latest_local_dockerfile=$(realpath latest-workflow-local-Dockerfile)
 
 _print "Building 'virtool/workflow' image with the latest version of 'virtool_workflow'..."
-docker build -t virtool/workflow -f $workflow_latest_dockerfile --build-arg "VIRTOOL_WORKFLOW_REPO=$virtool_workflow_repo" --no-cache .
+if [[ -v LOCAL_VIRTOOL_WORKFLOW_PATH ]]
+then
+    cd $LOCAL_VIRTOOL_WORKFLOW_PATH
+    docker build -t virtool/workflow -f $workflow_latest_local_dockerfile .
+    cd $cwd
+else
+    docker build -t virtool/workflow -f $workflow_latest_dockerfile \
+        --build-arg "VIRTOOL_WORKFLOW_REPO=$virtool_workflow_repo" \
+        .
+fi
 
 _print "Building 'virtool/integration_test_workflow'..."
 docker build -t virtool/integration_test_workflow -f $test_dockerfile workflow
 
-temp=$(mktemp -d build-vt-jobs-ap1-XXX)
-_print_one_line "Created temporary directory... $temp"
+if [[ -v LOCAL_VIRTOOL_PATH ]]
+then 
+    cd $LOCAL_VIRTOOL_PATH
+else
+    temp=$(mktemp -d build-vt-jobs-ap1-XXX)
+    _print_one_line "Created temporary directory... $temp"
 
-# Ensure temporary directory is removed and return to previous directory
-cmd="cd $cwd && rm -rf $temp"
-trap "$cmd" SIGINT
-trap "$cmd" EXIT
+    # Ensure temporary directory is removed and return to previous directory
+    cmd="cd $cwd && rm -rf $temp"
+    trap "$cmd" SIGINT
+    trap "$cmd" EXIT
 
 
-cd $temp
+    cd $temp
+    git clone --single-branch --branch $virtool_branch $virtool_repo && \
+        cd virtool 
+fi
 
 _print "Building 'virtool/job-api' with the latest changes..."
-git clone --single-branch --branch $virtool_branch $virtool_repo && \
-cd virtool && \
 
 docker build -t virtool/jobs-api -f $dockerfile .
 

--- a/integration_test_workflow/docker-compose.dev.yml
+++ b/integration_test_workflow/docker-compose.dev.yml
@@ -1,10 +1,5 @@
 version: "3.1"
 services:
-    integration_test_workflow:
-        image: virtool/integration_test_workflow
-        depends_on:
-            - job-api
-
     job-api:
         image: virtool/jobs-api
         depends_on: 

--- a/integration_test_workflow/docker-compose.dev.yml
+++ b/integration_test_workflow/docker-compose.dev.yml
@@ -14,8 +14,9 @@ services:
             jobsAPI
             --fake
             --host=0.0.0.0
+            --port=9990
         ports:
-            - "9950:9950"
+            - "9990:9990"
 
     mongo:
         image: mongo:4.4

--- a/integration_test_workflow/docker-compose.dev.yml
+++ b/integration_test_workflow/docker-compose.dev.yml
@@ -13,6 +13,9 @@ services:
             --redis-connection-string="redis://redis:6379"
             jobsAPI
             --fake
+            --host=0.0.0.0
+        ports:
+            - "9950:9950"
 
     mongo:
         image: mongo:4.4

--- a/integration_test_workflow/docker-compose.test.yml
+++ b/integration_test_workflow/docker-compose.test.yml
@@ -6,3 +6,4 @@ services:
             - job-api
         command: >
             --dev-mode true
+            --jobs-api-url http://job-api:9990/api

--- a/integration_test_workflow/docker-compose.test.yml
+++ b/integration_test_workflow/docker-compose.test.yml
@@ -1,0 +1,6 @@
+version: "3.1"
+services:
+    integration_test_workflow:
+        image: virtool/integration_test_workflow
+        depends_on:
+            - job-api

--- a/integration_test_workflow/docker-compose.test.yml
+++ b/integration_test_workflow/docker-compose.test.yml
@@ -4,3 +4,5 @@ services:
         image: virtool/integration_test_workflow
         depends_on:
             - job-api
+        command: >
+            --dev-mode true

--- a/integration_test_workflow/latest-workflow-Dockerfile
+++ b/integration_test_workflow/latest-workflow-Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.9-buster as pip_install
+FROM python:3.9-buster as remote_pip_install
 ARG VIRTOOL_WORKFLOW_REPO
 RUN pip install --user "git+${VIRTOOL_WORKFLOW_REPO}"
 
+
 FROM virtool/workflow:0.0.0
-COPY --from=pip_install /root/.local /root/.local
+COPY --from=remote_pip_install_pip_install /root/.local /root/.local

--- a/integration_test_workflow/latest-workflow-local-Dockerfile
+++ b/integration_test_workflow/latest-workflow-local-Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9-buster as local_pip_install
+WORKDIR install
+COPY . .
+RUN pip install --user .
+
+
+FROM virtool/workflow:0.0.0
+COPY --from=local_pip_install /root/.local /root/.local

--- a/integration_test_workflow/run.sh
+++ b/integration_test_workflow/run.sh
@@ -9,7 +9,7 @@ _print() {
 }
 
 _print 'Running build script...'
-./build.sh $@
-_print 'Starting docker-compose...'
+./build.sh && \
+_print 'Starting docker-compose...' && \
 docker-compose up --exit-code-from=integration_test_workflow
 _print "DONE"

--- a/integration_test_workflow/run.sh
+++ b/integration_test_workflow/run.sh
@@ -9,7 +9,7 @@ _print() {
 }
 
 _print 'Running build script...'
-./build.sh && \
+./build.sh "$@" && \
 _print 'Starting docker-compose...' && \
 docker-compose up --exit-code-from=integration_test_workflow
 _print "DONE"

--- a/integration_test_workflow/workflow/Dockerfile
+++ b/integration_test_workflow/workflow/Dockerfile
@@ -2,5 +2,5 @@ FROM virtool/workflow
 
 COPY . .
 
-ENTRYPOINT ["workflow", "run", "test_job"]
+ENTRYPOINT ["workflow", "run", "integration_test_job"]
 

--- a/integration_test_workflow/workflow/Dockerfile
+++ b/integration_test_workflow/workflow/Dockerfile
@@ -2,5 +2,5 @@ FROM virtool/workflow
 
 COPY . .
 
-ENTRYPOINT ["workflow", "run", "integration_test_job"]
+ENTRYPOINT ["./entrypoint.sh"]
 

--- a/integration_test_workflow/workflow/entrypoint.sh
+++ b/integration_test_workflow/workflow/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Entrypoint script for the integration test workflow.
+
+workflow run "$@" integration_test_job

--- a/integration_test_workflow/workflow/integration_test_workflows/test_sample.py
+++ b/integration_test_workflow/workflow/integration_test_workflows/test_sample.py
@@ -3,5 +3,5 @@ from virtool_workflow.data_model.samples import Sample
 
 
 @step
-def test_sample_fixture_available(sample):
-    assert isinstance(sample, Sample)
+def test_sample_fixture_available():
+    ...

--- a/integration_test_workflow/workflow/run_workflow.sh
+++ b/integration_test_workflow/workflow/run_workflow.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+workflow run --jobs-api-url http://localhost:9950 --is-analysis-workflow true integration_test_workflow

--- a/integration_test_workflow/workflow/run_workflow.sh
+++ b/integration_test_workflow/workflow/run_workflow.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-workflow run --jobs-api-url http://localhost:9950/api "$@" --is-analysis-workflow true integration_test_job
+workflow run --jobs-api-url http://localhost:9990/api "$@" --is-analysis-workflow true integration_test_job

--- a/integration_test_workflow/workflow/run_workflow.sh
+++ b/integration_test_workflow/workflow/run_workflow.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-workflow run --jobs-api-url http://localhost:9950 --is-analysis-workflow true integration_test_workflow
+workflow run --jobs-api-url http://localhost:9950/api "$@" --is-analysis-workflow true integration_test_job

--- a/integration_test_workflow/workflow/workflow.py
+++ b/integration_test_workflow/workflow/workflow.py
@@ -1,6 +1,11 @@
-from integration_test_workflows import (test_hmms, test_indexes, test_sample,
-                                        test_subtractions)
-from virtool_workflow import features, hooks
+import logging
+from integration_test_workflows import (
+    test_hmms,
+    test_indexes,
+    test_sample,
+    test_subtractions,
+)
+from virtool_workflow import features, hooks, fixture
 from virtool_workflow.analysis.features.trimming import Trimming
 from virtool_workflow.decorator_api import collect, step
 from virtool_workflow.execution.run_in_executor import FunctionExecutor
@@ -15,21 +20,29 @@ features.install(
 )
 
 
+@fixture
+def logger():
+    return logging.getLogger(__name__)
+
+
+@hooks.on_update
+def log_updates(update, logger):
+    logger.info(f"Sent update: {update}")
+
+
 @step
 def test_results_available(results):
     assert results is not None
     assert isinstance(results, dict)
+    return "Results fixture available"
 
 
 @step
-def test_builtin_fixtures_available(
-        workflow, 
-        run_in_executor, 
-        run_subprocess
-):
+def test_builtin_fixtures_available(workflow, run_in_executor, run_subprocess):
     assert isinstance(workflow, Workflow)
     assert isinstance(run_in_executor, FunctionExecutor)
     assert isinstance(run_subprocess, RunSubprocess)
+    return "Builtin fixtures available"
 
 
 @step
@@ -45,3 +58,5 @@ async def test_execution_fixture(execution):
     await execution.send_update("UPDATE")
 
     assert "UPDATE" in updates
+
+    return "`execution.send_update()` working"

--- a/integration_test_workflow/workflow/workflow.py
+++ b/integration_test_workflow/workflow/workflow.py
@@ -1,21 +1,17 @@
 from integration_test_workflows import (test_hmms, test_indexes, test_sample,
                                         test_subtractions)
-from virtool_workflow import features
+from virtool_workflow import features, hooks
 from virtool_workflow.analysis.features.trimming import Trimming
 from virtool_workflow.decorator_api import collect, step
 from virtool_workflow.execution.run_in_executor import FunctionExecutor
 from virtool_workflow.execution.run_subprocess import RunSubprocess
+from virtool_workflow.execution.workflow_execution import WorkflowExecution
 from virtool_workflow.workflow import Workflow
 from virtool_workflow.workflow_feature.merge_workflows import MergeWorkflows
 
 features.install(
     Trimming(),
-    MergeWorkflows(
-        test_hmms,
-        test_indexes,
-        test_sample,
-        test_subtractions,
-    ),
+    MergeWorkflows(test_hmms, test_indexes, test_sample, test_subtractions,),
 )
 
 
@@ -26,7 +22,26 @@ def test_results_available(results):
 
 
 @step
-def test_builtin_fixtures_available(workflow, run_in_executor, run_subprocess):
+def test_builtin_fixtures_available(
+        workflow, 
+        run_in_executor, 
+        run_subprocess
+):
     assert isinstance(workflow, Workflow)
     assert isinstance(run_in_executor, FunctionExecutor)
-    assert isinstance(run_subprocess,  RunSubprocess)
+    assert isinstance(run_subprocess, RunSubprocess)
+
+
+@step
+async def test_execution_fixture(execution):
+    assert isinstance(execution, WorkflowExecution)
+
+    updates = []
+
+    @hooks.on_update
+    def follow_updates(update):
+        updates.append(update)
+
+    await execution.send_update("UPDATE")
+
+    assert "UPDATE" in updates

--- a/integration_test_workflow/workflow/workflow.py
+++ b/integration_test_workflow/workflow/workflow.py
@@ -13,6 +13,7 @@ from virtool_workflow.execution.run_subprocess import RunSubprocess
 from virtool_workflow.execution.workflow_execution import WorkflowExecution
 from virtool_workflow.workflow import Workflow
 from virtool_workflow.workflow_feature.merge_workflows import MergeWorkflows
+from virtool_workflow.data_model.jobs import Job
 
 features.install(
     Trimming(),
@@ -44,6 +45,9 @@ def test_builtin_fixtures_available(workflow, run_in_executor, run_subprocess):
     assert isinstance(run_subprocess, RunSubprocess)
     return "Builtin fixtures available"
 
+@step
+def test_job_availaible(job):
+    assert isinstance(job, Job)
 
 @step
 async def test_execution_fixture(execution):
@@ -60,3 +64,8 @@ async def test_execution_fixture(execution):
     assert "UPDATE" in updates
 
     return "`execution.send_update()` working"
+
+
+@step
+async def test_scope_fixture(scope):
+    ...

--- a/tests/virtool_workflow/api/test_jobs.py
+++ b/tests/virtool_workflow/api/test_jobs.py
@@ -1,8 +1,9 @@
 from virtool_workflow.api import jobs
 from virtool_workflow.data_model import Status
 from virtool_workflow.testing import install_as_pytest_fixtures
+from virtool_workflow.config import fixtures as config
 
-install_as_pytest_fixtures(globals(), jobs.acquire_job)
+install_as_pytest_fixtures(globals(), jobs.acquire_job, config.mem, config.proc)
 
 
 async def test_job_can_be_acquired(acquire_job):

--- a/tests/virtool_workflow/config/test_config.py
+++ b/tests/virtool_workflow/config/test_config.py
@@ -46,7 +46,7 @@ def test_fixture_group_can_be_applied_to_click_command(click_runner):
 
 
 def test_config_fixtures_get_added_as_options(click_runner):
-    result = click_runner.invoke(cli, ["--help"])
+    result = click_runner.invoke(cli, ["run", "--help"])
 
     for opt in ("--data-path", "--work-path"):
         assert opt in result.output

--- a/tests/virtool_workflow/test_workflow_scope.py
+++ b/tests/virtool_workflow/test_workflow_scope.py
@@ -11,7 +11,7 @@ def generator_fixture():
 async def test_workflow_scope_closes():
     workflow_scope["item"] = "value"
 
-    await hooks.on_finish.trigger(workflow_scope)
+    await hooks.on_finalize.trigger(workflow_scope)
 
     assert "item" not in workflow_scope
 
@@ -22,15 +22,8 @@ async def test_generator_fixture_finishes():
     assert workflow_scope["generator_fixture"]
 
     try:
-        await hooks.on_finish.trigger(workflow_scope)
+        await hooks.on_finalize.trigger(workflow_scope)
     except ValueError:
         return
 
     assert False
-
-
-
-
-
-
-

--- a/virtool_workflow/api/errors.py
+++ b/virtool_workflow/api/errors.py
@@ -4,7 +4,9 @@ from typing import Dict, Type, List
 
 class JobAlreadyAcquired(Exception):
     def __init__(self, job_id: str):
-        super(JobAlreadyAcquired, self).__init__(f"Job {job_id} is has already been acquired.")
+        super(JobAlreadyAcquired, self).__init__(
+            f"Job {job_id} is has already been acquired."
+        )
 
 
 class JobsAPIServerError(Exception):
@@ -24,9 +26,11 @@ class AlreadyFinalized(Exception):
 
 
 @asynccontextmanager
-async def raising_errors_by_status_code(response,
-                                        accept: List[int] = None,
-                                        status_codes_to_exceptions: Dict[int, Type[Exception]] = None):
+async def raising_errors_by_status_code(
+    response,
+    accept: List[int] = None,
+    status_codes_to_exceptions: Dict[int, Type[Exception]] = None,
+):
     """
     Raise exceptions based on the result status code.
 
@@ -50,7 +54,7 @@ async def raising_errors_by_status_code(response,
         accept = list(range(200, 299))
 
     response_json = None
-    if response.content_type == 'application/json':
+    if response.content_type == "application/json":
         try:
             response_json = await response.json()
         except UnicodeDecodeError:
@@ -58,7 +62,11 @@ async def raising_errors_by_status_code(response,
 
     if response.status in status_codes_to_exceptions:
         if response_json:
-            response_message = response_json["message"] if "message" in response_json else str(response_json)
+            response_message = (
+                response_json["message"]
+                if "message" in response_json
+                else str(response_json)
+            )
         else:
             try:
                 response_message = await response.text()
@@ -69,4 +77,6 @@ async def raising_errors_by_status_code(response,
     if response.status in accept:
         yield response_json
     else:
-        raise ValueError(f"Status code {response.status} not handled")
+        raise ValueError(
+            f"Status code {response.status} not handled for response\n {response}"
+        )

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -1,12 +1,22 @@
-from typing import Callable, Optional, Awaitable
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
 
 import aiohttp
 
-from .errors import raising_errors_by_status_code
 from ..data_model import Job, Status
+from .errors import (
+    JobAlreadyAcquired,
+    JobsAPIServerError,
+    raising_errors_by_status_code,
+)
+
+logger = logging.getLogger(__name__)
 
 
-async def acquire_job_by_id(job_id: str, http: aiohttp.ClientSession, jobs_api_url):
+async def acquire_job_by_id(
+    job_id: str, http: aiohttp.ClientSession, jobs_api_url: str, mem: int, proc: int
+):
     """
     Acquire the job with a given ID using the jobs API.
 
@@ -19,21 +29,32 @@ async def acquire_job_by_id(job_id: str, http: aiohttp.ClientSession, jobs_api_u
     async with http.patch(
         f"{jobs_api_url}/jobs/{job_id}", json={"acquired": True}
     ) as response:
-        async with raising_errors_by_status_code(response) as document:
+        async with raising_errors_by_status_code(
+            response, status_codes_to_exceptions={"400": JobAlreadyAcquired}
+        ) as document:
+            logger.info(document)
             return Job(
                 id=document["id"],
                 args=document["args"],
-                mem=document["mem"],
-                proc=document["proc"],
+                mem=document["mem"] if "mem" in document else mem,
+                proc=document["proc"] if "proc" in document else proc,
                 status=document["status"],
                 task=document["task"],
                 key=document["key"],
             )
 
 
-def acquire_job(http: aiohttp.ClientSession, jobs_api_url: str):
-    async def _job_provider(job_id: str):
-        return await acquire_job_by_id(job_id, http, jobs_api_url)
+def acquire_job(http: aiohttp.ClientSession, jobs_api_url: str, mem: int, proc: int):
+    async def _job_provider(job_id: str, retry=3, timeout=3):
+        try:
+            logger.debug(f"Acquiring {job_id}")
+            return await acquire_job_by_id(job_id, http, jobs_api_url, mem, proc)
+        except aiohttp.client_exceptions.ClientConnectionError as error:
+            if retry > 0:
+                await asyncio.sleep(timeout)
+                return await _job_provider(job_id, retry=retry - 1)
+
+        raise JobsAPIServerError("Unable to connect to server.")
 
     return _job_provider
 

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -16,7 +16,9 @@ async def acquire_job_by_id(job_id: str, http: aiohttp.ClientSession, jobs_api_u
 
     :return: a :class:`virtool_workflow.data_model.Job` instance with an api key (.key attribute)
     """
-    async with http.patch(f"{jobs_api_url}/jobs/{job_id}", json={"acquired": True}) as response:
+    async with http.patch(
+        f"{jobs_api_url}/jobs/{job_id}", json={"acquired": True}
+    ) as response:
         async with raising_errors_by_status_code(response) as document:
             return Job(
                 id=document["id"],
@@ -43,13 +45,18 @@ def push_status(job: Job, http: aiohttp.ClientSession, jobs_api_url: str) -> Pus
     """Update the status of the current job."""
 
     async def _push_status(state: str, stage: str, progress: int, error: str = None):
-        async with http.post(f"{jobs_api_url}/jobs/{job.id}/status", json={
-            "state": state,
-            "stage": stage,
-            "error": error,
-            "progress": progress,
-        }) as response:
-            async with raising_errors_by_status_code(response, accept=[200]) as status_json:
+        async with http.post(
+            f"{jobs_api_url}/jobs/{job.id}/status",
+            json={
+                "state": state,
+                "stage": stage,
+                "error": error,
+                "progress": progress,
+            },
+        ) as response:
+            async with raising_errors_by_status_code(
+                response, accept=[200]
+            ) as status_json:
                 return Status(**status_json)
 
     return _push_status

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -6,20 +6,19 @@ from virtool_workflow import runtime
 from virtool_workflow.config.fixtures import options
 
 
-@options.add_options
 @click.group()
-@click.pass_context
-def cli(ctx, **kwargs):
-    ctx.obj = kwargs
+def cli(**kwargs):
+    ...
+
 
 
 async def _run(**kwargs):
     await runtime.start(**kwargs)
 
 
+@options.add_options
 @cli.command()
-@click.pass_obj
-def run(obj, **kwargs):
+def run(**kwargs):
     """Run a workflow."""
     asyncio.run(_run(**obj, **kwargs))
 

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -2,14 +2,13 @@
 import asyncio
 import click
 
-from virtool_workflow import runtime
+from virtool_workflow.runtime import runtime
 from virtool_workflow.config.fixtures import options
 
 
 @click.group()
-def cli(**kwargs):
+def cli():
     ...
-
 
 
 async def _run(**kwargs):
@@ -20,7 +19,7 @@ async def _run(**kwargs):
 @cli.command()
 def run(**kwargs):
     """Run a workflow."""
-    asyncio.run(_run(**obj, **kwargs))
+    asyncio.run(_run(**kwargs))
 
 
 def cli_main():

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -16,10 +16,11 @@ async def _run(**kwargs):
 
 
 @options.add_options
+@click.argument("job_id")
 @cli.command()
-def run(**kwargs):
+def run(job_id, **kwargs):
     """Run a workflow."""
-    asyncio.run(_run(**kwargs))
+    asyncio.run(_run(job_id=job_id, **kwargs))
 
 
 def cli_main():

--- a/virtool_workflow/discovery.py
+++ b/virtool_workflow/discovery.py
@@ -22,6 +22,10 @@ FixtureImportType = Iterable[
 ]
 
 
+class WorkflowDiscoveryError(Exception):
+    ...
+
+
 def import_module_from_file(module_name: str, path: Path) -> ModuleType:
     """
     Import a module from a file.
@@ -102,7 +106,10 @@ def discover_workflow(path: Path) -> Workflow:
     :raises StopIteration: When no instance of virtool_workflow.Workflow can be found.
     """
     logger.info(f"Importing module from {path}")
-    module = import_module_from_file(path.name.rstrip(path.suffix), path)
+    try:
+        module = import_module_from_file(path.name.rstrip(path.suffix), path)
+    except FileNotFoundError as not_found:
+        raise WorkflowDiscoveryError(f"There is no such file {path}") from not_found
 
     workflow = next((attr for attr in module.__dict__.values() if isinstance(attr, Workflow)), None)
 

--- a/virtool_workflow/execution/run_in_executor.py
+++ b/virtool_workflow/execution/run_in_executor.py
@@ -1,6 +1,6 @@
 """Helper functions for threading and running subprocesses within Virtool Workflows."""
 from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Any, Protocol, Coroutine
+from typing import Callable, Any, Protocol, Coroutine, runtime_checkable
 
 from virtool_workflow.fixtures.workflow_fixture import fixture
 
@@ -11,6 +11,7 @@ def thread_pool_executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor()
 
 
+@runtime_checkable
 class FunctionExecutor(Protocol):
     def __call__(self, func: Callable[[Any], Any], *args: Any, **kwargs: Any) -> Coroutine:
         ...

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -1,7 +1,7 @@
 import asyncio
 import asyncio.subprocess
 from logging import getLogger
-from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol, Any
+from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol, Any, runtime_checkable
 
 from virtool_workflow import fixture, hooks
 
@@ -10,6 +10,7 @@ logger = getLogger(__name__)
 RunSubprocessHandler = Callable[[str], Awaitable[None]]
 
 
+@runtime_checkable
 class RunSubprocess(Protocol):
     def __call__(self,
                  command: List[str],

--- a/virtool_workflow/execution/workflow_execution.py
+++ b/virtool_workflow/execution/workflow_execution.py
@@ -133,10 +133,15 @@ class WorkflowExecution:
     async def execute(self) -> Dict[str, Any]:
         """Execute the workflow and return the result."""
         try:
-            return await self._execute()
+            result = await self._execute()
         except Exception as e:
             await hooks.on_failure.trigger(self.scope, e)
             raise e
+
+        await hooks.on_result.trigger(self.scope)
+        await hooks.on_success.trigger(self.scope)
+
+        return result
 
     async def _execute(self) -> Dict[str, Any]:
         logger.debug(f"Starting execution of {self.workflow}")
@@ -161,9 +166,6 @@ class WorkflowExecution:
 
         logger.debug("Workflow finished")
         logger.debug(f"Result: \n{pprint.pformat(result)}")
-
-        await hooks.on_result.trigger(self.scope)
-        await hooks.on_success.trigger(self.scope)
 
         return result
 

--- a/virtool_workflow/execution/workflow_execution.py
+++ b/virtool_workflow/execution/workflow_execution.py
@@ -18,11 +18,11 @@ class WorkflowError(Exception):
     """An exception occurring during the execution of a workflow."""
 
     def __init__(
-            self,
-            cause: Exception,
-            workflow: Workflow,
-            context: Optional["WorkflowExecution"],
-            max_traceback_depth: int = 50
+        self,
+        cause: Exception,
+        workflow: Workflow,
+        context: Optional["WorkflowExecution"],
+        max_traceback_depth: int = 50,
     ):
         """
 
@@ -40,15 +40,17 @@ class WorkflowError(Exception):
         self.traceback_data = {
             "type": exception.__name__,
             "traceback": traceback.format_tb(trace_info, max_traceback_depth),
-            "details": [str(arg) for arg in value.args]
+            "details": [str(arg) for arg in value.args],
         }
 
         super().__init__(str(cause))
 
     def __str__(self):
-        return (f"{self.cause}\n\n"
-                f"Context: {self.context}\n"
-                f"Workflow: {self.workflow}\n")
+        return (
+            f"{self.cause}\n\n"
+            f"Context: {self.context}\n"
+            f"Workflow: {self.workflow}\n"
+        )
 
 
 State = Enum("State", "WAITING STARTUP RUNNING CLEANUP FINISHED")
@@ -94,24 +96,20 @@ class WorkflowExecution:
 
         :param new_state: The new state that should be applied.
         """
-        logger.debug(
-            f"Changing the execution state from {self._state} to {new_state}")
+        logger.debug(f"Changing the execution state from {self._state} to {new_state}")
         await hooks.on_state_change.trigger(self.scope, self._state, new_state)
         self._state = new_state
         return new_state
 
     async def _run_step(
-            self,
-            step: Callable[[], Coroutine[Any, Any, Optional[str]]],
+        self, step: Callable[[], Coroutine[Any, Any, Optional[str]]],
     ):
         try:
-            logger.info(
-                f"Beginning step #{self.current_step}: {step.__name__}")
+            logger.debug(f"Beginning step #{self.current_step}: {step.__name__}")
             return await step()
         except Exception as exception:
             self.error = exception
-            error = WorkflowError(
-                cause=exception, workflow=self.workflow, context=self)
+            error = WorkflowError(cause=exception, workflow=self.workflow, context=self)
             callback_results = await hooks.on_error.trigger(self.scope, error)
 
             if callback_results:
@@ -123,8 +121,9 @@ class WorkflowExecution:
         for step in steps:
             if count_steps:
                 self.current_step += 1
-                self.progress = float(self.current_step) / \
-                                float(len(self.workflow.steps))
+                self.progress = float(self.current_step) / float(
+                    len(self.workflow.steps)
+                )
             update = await self._run_step(step)
             if count_steps:
                 await hooks.on_workflow_step.trigger(self.scope, update)
@@ -140,7 +139,7 @@ class WorkflowExecution:
             raise e
 
     async def _execute(self) -> Dict[str, Any]:
-        logger.info(f"Starting execution of {self.workflow}")
+        logger.debug(f"Starting execution of {self.workflow}")
 
         self.scope["workflow"] = self.workflow
         self.scope["execution"] = self
@@ -148,9 +147,11 @@ class WorkflowExecution:
 
         bound_workflow = await self.scope.bind_to_workflow(self.workflow)
 
-        for state, steps, count_steps in ((State.STARTUP, bound_workflow.on_startup, False),
-                                          (State.RUNNING, bound_workflow.steps, True),
-                                          (State.CLEANUP, bound_workflow.on_cleanup, False)):
+        for state, steps, count_steps in (
+            (State.STARTUP, bound_workflow.on_startup, False),
+            (State.RUNNING, bound_workflow.steps, True),
+            (State.CLEANUP, bound_workflow.on_cleanup, False),
+        ):
             await self._set_state(state)
             await self._run_steps(steps, count_steps)
 
@@ -158,7 +159,7 @@ class WorkflowExecution:
 
         result = self.scope["results"]
 
-        logger.info("Workflow finished")
+        logger.debug("Workflow finished")
         logger.debug(f"Result: \n{pprint.pformat(result)}")
 
         await hooks.on_result.trigger(self.scope)

--- a/virtool_workflow/execution/workflow_execution.py
+++ b/virtool_workflow/execution/workflow_execution.py
@@ -108,6 +108,8 @@ class WorkflowExecution:
             logger.debug(f"Beginning step #{self.current_step}: {step.__name__}")
             return await step()
         except Exception as exception:
+            logger.exception(exception)
+
             self.error = exception
             error = WorkflowError(cause=exception, workflow=self.workflow, context=self)
             callback_results = await hooks.on_error.trigger(self.scope, error)

--- a/virtool_workflow/fixtures/scope.py
+++ b/virtool_workflow/fixtures/scope.py
@@ -4,11 +4,13 @@ import logging
 import pprint
 from contextlib import AbstractAsyncContextManager, suppress
 from functools import wraps
-from inspect import signature, Parameter
+from inspect import Parameter, signature
 from typing import Any, Callable
 
-from virtool_workflow.fixtures.errors import FixtureMultipleYield, FixtureNotAvailable
-from virtool_workflow.fixtures.providers import FixtureProvider, InstanceFixtureGroup, FixtureGroup
+from virtool_workflow.fixtures.errors import (FixtureMultipleYield,
+                                              FixtureNotAvailable)
+from virtool_workflow.fixtures.providers import (FixtureGroup, FixtureProvider,
+                                                 InstanceFixtureGroup)
 from virtool_workflow.workflow import Workflow
 
 logger = logging.getLogger(__name__)
@@ -44,7 +46,7 @@ class FixtureScope(AbstractAsyncContextManager, InstanceFixtureGroup):
 
     async def __aenter__(self):
         """Return this instance when `with` statement is used."""
-        logger.debug(f"Opening a new {FixtureScope.__name__}")
+        logger.info(f"Opening a new {FixtureScope.__name__}")
         return self
 
     async def close(self):
@@ -54,7 +56,8 @@ class FixtureScope(AbstractAsyncContextManager, InstanceFixtureGroup):
         Return execution to each of the generator fixtures and remove
         references to them.
         """
-        logger.debug(f"Closing {FixtureScope.__name__} {self}")
+        logger.info(f"Closing {FixtureScope.__name__}")
+        logger.debug(f"Closed {pprint.pformat(self)}")
         # return control to the generator fixtures which are still left open
         self.clear()
 

--- a/virtool_workflow/fixtures/scoping.py
+++ b/virtool_workflow/fixtures/scoping.py
@@ -6,7 +6,7 @@ workflow_scope = FixtureScope(workflow_fixtures)
 """The :class:`FixtureScope` to be used for workflow runs."""
 
 
-@hooks.on_finish
+@hooks.on_finalize
 async def _close_scopes():
     """Close :class:`FixtureScope` instances when the workflow finishes."""
     await workflow_scope.close()

--- a/virtool_workflow/hooks.py
+++ b/virtool_workflow/hooks.py
@@ -42,6 +42,14 @@ Triggered when a job finishes, regardless of success or failure.
 """
 
 
+on_finalize = FixtureHook("on_finalize")
+"""
+Triggered after job finishes, regardless of success or failure.
+
+Intended for finalization actions such as closing the fixture scope.
+"""
+
+
 @on_success
 async def _trigger_on_finish_from_on_success(scope):
     await on_finish.trigger(scope)
@@ -125,6 +133,7 @@ __all__ = [
     "on_workflow_step",
     "on_success",
     "on_failure",
+    "on_finalize",
     "on_workflow_failure",
     "on_workflow_finish",
     "on_finish",

--- a/virtool_workflow/runtime/fixtures.py
+++ b/virtool_workflow/runtime/fixtures.py
@@ -9,14 +9,20 @@ from virtool_workflow.execution.run_subprocess import run_subprocess
 from virtool_workflow.fixtures import FixtureGroup
 from virtool_workflow.results import results
 from virtool_workflow.runtime.providers import providers
+from virtool_workflow.api.jobs import acquire_job
+from virtool_workflow.config.fixtures import job_id
+from virtool_workflow.api.scope import api_fixtures
 
 
 logger = logging.getLogger(__name__)
 
 _workflow_fixtures = [
+    job_id,
     results,
     config.work_path,
     config.data_path,
+    config.mem, 
+    config.proc,
     run_in_executor,
     thread_pool_executor,
     run_subprocess,
@@ -26,14 +32,13 @@ _workflow_fixtures = [
 workflow = FixtureGroup(
     *_workflow_fixtures,
     providers["job"],
-    mem=lambda job: job.mem,
-    proc=lambda job: job.proc,
+    **api_fixtures,
 )
 """A :class:`FixtureGroup` containing all fixtures available within workflows."""
 
 analysis = FixtureGroup(
     *_workflow_fixtures,
-    **providers,
+    **dict(providers, **api_fixtures),
     **{k: getattr(analysis_fixtures, k) for k in analysis_fixtures.__all__},
 )
 """A :class:`FixtureGroup` containing all fixtures excusive to analysis workflows."""

--- a/virtool_workflow/runtime/providers.py
+++ b/virtool_workflow/runtime/providers.py
@@ -11,10 +11,9 @@ from virtool_workflow.config import fixtures as config
 from virtool_workflow.data_model import Job
 from virtool_workflow.fixtures import FixtureGroup
 
-providers = FixtureGroup(config.job_id,
-                         jobs.acquire_job,
-                         jobs.push_status,
-                         **api_fixtures)
+providers = FixtureGroup(
+    config.job_id, jobs.acquire_job, jobs.push_status, **api_fixtures
+)
 """A :class:`FixtureGroup` containing all data provider fixtures."""
 
 
@@ -44,7 +43,9 @@ def sample_provider(job, http, jobs_api_url) -> SampleProvider:
 
 
 @providers.fixture
-def subtraction_providers(job, http, jobs_api_url, work_path) -> List[SubtractionProvider]:
+def subtraction_providers(
+    job, http, jobs_api_url, work_path
+) -> List[SubtractionProvider]:
     ids = job.args["subtraction_id"]
     if isinstance(ids, str) or isinstance(ids, bytes):
         ids = [ids]
@@ -52,5 +53,7 @@ def subtraction_providers(job, http, jobs_api_url, work_path) -> List[Subtractio
     subtraction_work_path = work_path / "subtractions"
     subtraction_work_path.mkdir()
 
-    return [SubtractionProvider(id_, http, jobs_api_url, subtraction_work_path)
-            for id_ in ids]
+    return [
+        SubtractionProvider(id_, http, jobs_api_url, subtraction_work_path)
+        for id_ in ids
+    ]

--- a/virtool_workflow/runtime/runtime.py
+++ b/virtool_workflow/runtime/runtime.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from virtool_workflow import discovery, FixtureScope, features
 from virtool_workflow.config.loading import load_config
 from virtool_workflow.config.fixtures import options
-from virtool_workflow.hooks import on_load_config
+from virtool_workflow.hooks import on_load_config, on_finalize
 from virtool_workflow.runtime import fixtures
 
 logger = logging.getLogger(__name__)
@@ -54,6 +54,7 @@ async def prepare_environment(**config):
     async with environment:
         await features.install_into_environment(environment)
         yield environment, workflow
+        await on_finalize.trigger(environment)
 
 
 async def start(**config):


### PR DESCRIPTION
- Adds `--local-virtool-workflow` and `--local-virtool` options to `build.sh` and `run.sh` scripts
    - Build the docker images based on the local files instead of pulling from github
- Update [README](integration_test_workflow/README.md) about new options.
- Test that the job can be acquired from the API server.