### PR TITLE
Add Basic Auth Header To Requests Once Job Is Acquired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ functions. Any standard function provided will be wrapped into an async function
 
 ### Poetry
 
-(poetry)[https://python-poetry.org/] is used to manage dependencies for the project.
+[poetry](https://python-poetry.org/) is used to manage dependencies for the project.
 
 To build the distribution;
 

--- a/tests/virtool_workflow/api/fixtures.py
+++ b/tests/virtool_workflow/api/fixtures.py
@@ -1,6 +1,7 @@
 import aiohttp
 import pytest
 from aiohttp import web
+from virtool_workflow.api.client import JobApiHttpSession
 
 from tests.virtool_workflow.api.mocks.mock_api import mock_routes
 
@@ -28,4 +29,5 @@ async def mock_jobs_api_app(loop):
 @pytest.fixture
 async def http(mock_jobs_api_app, aiohttp_client) -> aiohttp.ClientSession:
     """Create an http client for accessing the mocked Jobs API."""
-    return await aiohttp_client(mock_jobs_api_app, auto_decompress=False)
+    session = await aiohttp_client(mock_jobs_api_app, auto_decompress=False)
+    return JobApiHttpSession(session)

--- a/tests/virtool_workflow/api/http/test_client.py
+++ b/tests/virtool_workflow/api/http/test_client.py
@@ -3,6 +3,8 @@ import pytest
 
 from virtool_workflow.api.client import authenticated_http
 from virtool_workflow.api.scope import api_scope
+from virtool_workflow.runtime import fixtures
+from virtool_workflow.fixtures.scope import FixtureScope
 
 
 @pytest.fixture
@@ -29,3 +31,13 @@ async def test_add_auth_headers_adds_auth():
 
     assert client.auth.login == f"job-{job_id}"
     assert client.auth.password == job_key
+
+
+async def test_auth_headers_applied_once_job_is_ready():
+    async with FixtureScope(fixtures.workflow) as scope:
+        job = await scope.get_or_instantiate("job")
+
+        http = scope["http"]
+
+        assert client.auth.login == f"job-{job.id}"
+        assert client.auth.password == job.key

--- a/tests/virtool_workflow/api/http/test_client.py
+++ b/tests/virtool_workflow/api/http/test_client.py
@@ -1,13 +1,31 @@
 import aiohttp
+import pytest
 
+from virtool_workflow.api.client import authenticated_http
 from virtool_workflow.api.scope import api_scope
 
 
-async def test_http_client():
-    client = await api_scope.get_or_instantiate("http")
+@pytest.fixture
+async def client():
+    return await api_scope.get_or_instantiate("http")
 
+
+async def test_http_client_does_close(client):
     assert isinstance(client, aiohttp.ClientSession)
 
     await api_scope.close()
 
     assert client.closed
+
+
+async def test_add_auth_headers_adds_auth():
+    job_id = "test_job"
+    job_key = "foobar"
+
+    api_scope["job_id"] = job_id
+    api_scope["key"] = job_key
+
+    client = await api_scope.instantiate(authenticated_http)
+
+    assert client.auth.login == f"job-{job_id}"
+    assert client.auth.password == job_key

--- a/virtool_workflow/api/client.py
+++ b/virtool_workflow/api/client.py
@@ -1,15 +1,37 @@
 import aiohttp
+from functools import wraps
 
 
 async def http():
     """:class:`Aiohttp.ClientSession` instance to be used for workflows."""
     async with aiohttp.ClientSession(auto_decompress=False) as session:
-        yield session
+        yield JobApiHttpSession(session)
 
 
 async def authenticated_http(job_id, key, http):
     """:class:`Aiohttp.ClientSession` instance which includes authentication headers for the jobs API."""
-    auth = aiohttp.BasicAuth(login=f"job-{job_id}", password=key)
+    http.auth = aiohttp.BasicAuth(login=f"job-{job_id}", password=key)
+    return http
 
-    async with aiohttp.ClientSession(auto_decompress=False, auth=auth) as session:
-        yield session
+
+class JobApiHttpSession:
+    """Wraps :class:`aiohttp.ClientSession` and adds authentication for the jobs API."""
+
+    def __init__(self, client: aiohttp.ClientSession, auth: aiohttp.BasicAuth = None):
+        self.client = client
+        self.auth = auth
+
+        self.delete = self._wrap_with_auth(self.client.delete)
+        self.get = self._wrap_with_auth(self.client.get)
+        self.patch = self._wrap_with_auth(self.client.patch)
+        self.post = self._wrap_with_auth(self.client.post)
+        self.put = self._wrap_with_auth(self.client.put)
+
+    def _wrap_with_auth(self, method):
+        @wraps(method)
+        def _method_with_auth(*args, noauth=False, **kwargs):
+            if "auth" not in kwargs and self.auth is not None and not noauth:
+                kwargs["auth"] = self.auth
+            return method(*args, **kwargs)
+
+        return _method_with_auth

--- a/virtool_workflow/api/client.py
+++ b/virtool_workflow/api/client.py
@@ -8,6 +8,7 @@ async def http():
 
 
 async def authenticated_http(job_id, key, http):
+    """:class:`Aiohttp.ClientSession` instance which includes authentication headers for the jobs API."""
     auth = aiohttp.BasicAuth(login=f"job-{job_id}", password=key)
 
     async with aiohttp.ClientSession(auto_decompress=False, auth=auth) as session:

--- a/virtool_workflow/api/client.py
+++ b/virtool_workflow/api/client.py
@@ -5,3 +5,10 @@ async def http():
     """:class:`Aiohttp.ClientSession` instance to be used for workflows."""
     async with aiohttp.ClientSession(auto_decompress=False) as session:
         yield session
+
+
+async def authenticated_http(job_id, key, http):
+    auth = aiohttp.BasicAuth(login=f"job-{job_id}", password=key)
+
+    async with aiohttp.ClientSession(auto_decompress=False, auth=auth) as session:
+        yield session

--- a/virtool_workflow/runtime/providers.py
+++ b/virtool_workflow/runtime/providers.py
@@ -10,6 +10,7 @@ from virtool_workflow.api.subtractions import SubtractionProvider
 from virtool_workflow.config import fixtures as config
 from virtool_workflow.data_model import Job
 from virtool_workflow.fixtures import FixtureGroup
+from virtool_workflow.api.client import authenticated_http
 
 providers = FixtureGroup(
     config.job_id, jobs.acquire_job, jobs.push_status, **api_fixtures
@@ -18,8 +19,14 @@ providers = FixtureGroup(
 
 
 @providers.fixture
-async def _job(job_id, acquire_job) -> Job:
-    return await acquire_job(job_id)
+async def _job(job_id, acquire_job, scope) -> Job:
+    job = await acquire_job(job_id)
+
+    scope["key"] = job.key
+    await scope.instantiate(authenticated_http)
+    scope["http"] = authenticated_http
+
+    return job
 
 
 @providers.fixture

--- a/virtool_workflow/runtime/providers.py
+++ b/virtool_workflow/runtime/providers.py
@@ -2,6 +2,7 @@ from typing import List
 
 from virtool_workflow.api import jobs
 from virtool_workflow.api.analysis import AnalysisProvider
+from virtool_workflow.api.client import authenticated_http
 from virtool_workflow.api.hmm import HMMsProvider
 from virtool_workflow.api.indexes import IndexProvider
 from virtool_workflow.api.samples import SampleProvider
@@ -10,7 +11,6 @@ from virtool_workflow.api.subtractions import SubtractionProvider
 from virtool_workflow.config import fixtures as config
 from virtool_workflow.data_model import Job
 from virtool_workflow.fixtures import FixtureGroup
-from virtool_workflow.api.client import authenticated_http
 
 providers = FixtureGroup(
     config.job_id, jobs.acquire_job, jobs.push_status, **api_fixtures
@@ -22,9 +22,7 @@ providers = FixtureGroup(
 async def _job(job_id, acquire_job, scope) -> Job:
     job = await acquire_job(job_id)
 
-    scope["key"] = job.key
-    await scope.instantiate(authenticated_http)
-    scope["http"] = authenticated_http
+    scope["http"] = await authenticated_http(job.id, job.key, scope["http"])
 
     return job
 
@@ -46,6 +44,7 @@ def index_provider(job, http, jobs_api_url) -> IndexProvider:
 
 @providers.fixture
 def sample_provider(job, http, jobs_api_url) -> SampleProvider:
+    print(http)
     return SampleProvider(job.args["sample_id"], http, jobs_api_url)
 
 


### PR DESCRIPTION
Ensures that the Authentication headers are added to requests once the `job` has been acquired.

This is accomplished by wrapping the `get`, `post`, `put`, `patch`, and `delete` methods of `aiohttp.ClientSession`. 

An optional `noauth` parameter is added to disable authentication for a particular request.