### PR TITLE
Update Workflow Client To Use PUT Instead of POST for File Uploads

### DIFF
--- a/tests/virtool_workflow/api/mocks/mock_analysis_routes.py
+++ b/tests/virtool_workflow/api/mocks/mock_analysis_routes.py
@@ -41,7 +41,7 @@ async def get_analysis(request):
     )
 
 
-@mock_routes.post("/api/analyses/{analysis_id}/files")
+@mock_routes.put("/api/analyses/{analysis_id}/files")
 async def upload_file(request):
     name = request.query.get("name")
     format = request.query.get("format")

--- a/tests/virtool_workflow/api/mocks/mock_cache_routes.py
+++ b/tests/virtool_workflow/api/mocks/mock_cache_routes.py
@@ -14,7 +14,7 @@ def create_cache_placeholder(request):
     raise NotImplementedError()
 
 
-@mock_routes.post("/api/caches/{key}/files")
+@mock_routes.put("/api/caches/{key}/files")
 def upload_cache_file(request):
     raise NotImplementedError()
 

--- a/tests/virtool_workflow/api/mocks/mock_index_routes.py
+++ b/tests/virtool_workflow/api/mocks/mock_index_routes.py
@@ -76,7 +76,7 @@ async def get_ref(request):
     }, status=200)
 
 
-@mock_routes.post("/api/indexes/{index_id}/files")
+@mock_routes.put("/api/indexes/{index_id}/files")
 async def upload_index_file(request):
     reader = await request.multipart()
     file = await reader.next()

--- a/tests/virtool_workflow/api/mocks/mock_sample_routes.py
+++ b/tests/virtool_workflow/api/mocks/mock_sample_routes.py
@@ -72,8 +72,8 @@ async def delete(request):
     return Response(status=204)
 
 
-@mock_routes.post("/api/samples/{sample_id}/artifacts")
-@mock_routes.post("/api/samples/{sample_id}/reads")
+@mock_routes.put("/api/samples/{sample_id}/artifacts")
+@mock_routes.put("/api/samples/{sample_id}/reads")
 async def upload_read_files(request):
     sample_id = request.match_info["sample_id"]
 
@@ -134,7 +134,7 @@ async def create_mock_cache(request):
         return not_found()
 
 
-@mock_routes.post("/api/samples/{sample_id}/caches/{key}/artifacts")
+@mock_routes.put("/api/samples/{sample_id}/caches/{key}/artifacts")
 async def upload_artifact_to_cache(request):
     sample_id = request.match_info["sample_id"]
     key = request.match_info["key"]

--- a/tests/virtool_workflow/api/mocks/mock_subtraction_routes.py
+++ b/tests/virtool_workflow/api/mocks/mock_subtraction_routes.py
@@ -46,7 +46,7 @@ def get_subtraction(request):
     return web.json_response(TEST_SUBTRACTION, status=200)
 
 
-@mock_routes.post("/api/subtractions/{subtraction_id}/files")
+@mock_routes.put("/api/subtractions/{subtraction_id}/files")
 async def upload_subtraction_file(request):
     name = request.query.get("name")
 

--- a/virtool_workflow/api/analysis.py
+++ b/virtool_workflow/api/analysis.py
@@ -8,7 +8,7 @@ import dateutil.parser
 
 from virtool_workflow.abc.data_providers import AbstractAnalysisProvider
 from virtool_workflow.api.errors import raising_errors_by_status_code
-from virtool_workflow.api.utils import upload_file_via_post
+from virtool_workflow.api.utils import upload_file_via_put
 from virtool_workflow.data_model.analysis import Analysis
 from virtool_workflow.data_model.files import VirtoolFile, VirtoolFileFormat
 
@@ -72,7 +72,7 @@ class AnalysisProvider(AbstractAnalysisProvider):
         return await get_analysis_by_id(self.id, self.http, self.api_url)
 
     async def upload(self, path: Path, format: VirtoolFileFormat):
-        return await upload_file_via_post(self.http,
+        return await upload_file_via_put(self.http,
                                           f"{self.api_url}/analyses/{self.id}/files",
                                           path,
                                           format)

--- a/virtool_workflow/api/caches.py
+++ b/virtool_workflow/api/caches.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from virtool_workflow.abc.caches.analysis_caches import ReadsCache
 from virtool_workflow.api.errors import NotFound, JobsAPIServerError, raising_errors_by_status_code
-from virtool_workflow.api.utils import upload_file_via_post, upload_file_via_put, read_file_from_response
+from virtool_workflow.api.utils import upload_file_via_put, read_file_from_response
 from virtool_workflow.caching.caches import GenericCacheWriter, GenericCaches, GenericCache
 from virtool_workflow.data_model.files import VirtoolFileFormat
 from virtool_workflow.execution.run_in_executor import FunctionExecutor
@@ -57,7 +57,7 @@ class RemoteReadsCacheWriter(GenericCacheWriter[ReadsCache]):
                                              path,
                                              params={})
 
-        return await upload_file_via_post(self.http, f"{self.url}/{self.key}/artifacts", path, params={
+        return await upload_file_via_put(self.http, f"{self.url}/{self.key}/artifacts", path, params={
             "name": path.name,
             "type": format_,
         })

--- a/virtool_workflow/api/indexes.py
+++ b/virtool_workflow/api/indexes.py
@@ -5,7 +5,7 @@ import aiohttp
 from virtool_workflow.abc.data_providers import AbstractIndexProvider
 from virtool_workflow.api.errors import raising_errors_by_status_code
 from virtool_workflow.api.utils import (read_file_from_response,
-                                        upload_file_via_post)
+                                        upload_file_via_put)
 from virtool_workflow.data_model import Reference
 from virtool_workflow.data_model.files import VirtoolFile, VirtoolFileFormat
 from virtool_workflow.data_model.indexes import Index
@@ -73,7 +73,7 @@ class IndexProvider(AbstractIndexProvider):
         :param format_: The format of the file.
         :return: A :class:`VirtoolFile` object.
         """
-        return await upload_file_via_post(self.http,
+        return await upload_file_via_put(self.http,
                                           f"{self.jobs_api_url}/indexes/{self._index_id}/files",
                                           path, format_)
 

--- a/virtool_workflow/api/samples.py
+++ b/virtool_workflow/api/samples.py
@@ -10,7 +10,7 @@ from virtool_workflow.analysis.utils import ReadPaths, make_read_paths
 from virtool_workflow.api.errors import (raising_errors_by_status_code,
                                          AlreadyFinalized,
                                          JobsAPIServerError)
-from virtool_workflow.api.utils import (upload_file_via_post,
+from virtool_workflow.api.utils import (upload_file_via_put,
                                         read_file_from_response)
 from virtool_workflow.data_model import Sample
 from virtool_workflow.data_model.files import VirtoolFileFormat, VirtoolFile
@@ -65,12 +65,12 @@ class SampleProvider(AbstractSampleProvider):
 
     async def upload(self, path: Path, format: VirtoolFileFormat = "fastq") -> VirtoolFile:
         if path.name in ("reads_1.fq.gz", "reads_2.fq.gz"):
-            return await upload_file_via_post(self.http, f"{self.url}/reads", path, params={
+            return await upload_file_via_put(self.http, f"{self.url}/reads", path, params={
                 "name": path.name,
                 "type": format
             })
 
-        return await upload_file_via_post(self.http, f"{self.url}/artifacts", path, params={
+        return await upload_file_via_put(self.http, f"{self.url}/artifacts", path, params={
             "name": path.name,
             "type": format
         })

--- a/virtool_workflow/api/subtractions.py
+++ b/virtool_workflow/api/subtractions.py
@@ -6,7 +6,9 @@ import aiohttp
 
 from virtool_workflow.abc.data_providers import AbstractSubtractionProvider
 from virtool_workflow.api.errors import raising_errors_by_status_code
-from virtool_workflow.api.utils import upload_file_via_post, read_file_from_response
+from virtool_workflow.api.utils import (upload_file_via_post, 
+                                        read_file_from_response,
+                                        upload_file_via_put)
 from virtool_workflow.data_model import Subtraction, NucleotideComposition
 
 
@@ -60,7 +62,7 @@ class SubtractionProvider(AbstractSubtractionProvider):
             - subtraction.rev.1.bt2
             - subtraction.rev.2.bt2
         """
-        return await upload_file_via_post(self.http, f"{self.api_url}/files", path)
+        return await upload_file_via_put(self.http, f"{self.api_url}/files", path)
 
     async def finalize(self, gc: Dict[str, Number]):
         """

--- a/virtool_workflow/api/subtractions.py
+++ b/virtool_workflow/api/subtractions.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from virtool_workflow.abc.data_providers import AbstractSubtractionProvider
 from virtool_workflow.api.errors import raising_errors_by_status_code
-from virtool_workflow.api.utils import (upload_file_via_post, 
+from virtool_workflow.api.utils import (upload_file_via_put, 
                                         read_file_from_response,
                                         upload_file_via_put)
 from virtool_workflow.data_model import Subtraction, NucleotideComposition


### PR DESCRIPTION
Changes all calls to `upload_file_via_post()` to `upload_file_via_put()` and updates mock API routes accordingly.