### PR TITLE
Run CI actions on develop branch

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - "release/*"
       - "master"
+      - "develop"
 
   push:
     branches:
       - "master"
+      - "develop"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Run CI actions when PRs or pushes are made against the `develop` branch.