### PR TITLE
Run Changelog Enforcer Only On PR from Release Branch

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -4,15 +4,14 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - "release/*"
       - "master"
 
 jobs:
     changelog:
+        if: contains('refs/heads/release', github.ref)
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v2
         - uses: dangoslen/changelog-enforcer@v2
           with:
             changeLogPath: 'CHANGELOG.md'
-            skipLabels: 'nochangelog'


### PR DESCRIPTION
Only run changelog enforcer if the PR is coming from a `release/{tag}` branch