### PR TITLE
Remove unused hooks

### DIFF
--- a/virtool_workflow/environment.py
+++ b/virtool_workflow/environment.py
@@ -20,7 +20,7 @@ class WorkflowEnvironment(AbstractWorkflowEnvironment, FixtureScope):
         """Execute a Workflow."""
         if workflow is None:
             workflow = self["workflow"]
-        await hooks.on_load_fixtures.trigger(self)
+
         return await WorkflowExecution(workflow, self)
 
     async def execute_function(self, func: callable):

--- a/virtool_workflow/hooks.py
+++ b/virtool_workflow/hooks.py
@@ -89,21 +89,6 @@ is provided which has an attribute (sharing the same name as the fixture) for ea
             ...
 """
 
-on_load_database = Hook("on_load_database")
-"""
-Triggered before the job document is loaded from the database.
-
-Allows the database to be initialized with additional data.
-"""
-
-use_job = Hook("use_job")
-"""
-Triggered before the job is loaded from the database.
-
-The return value from this hook will be used as the Job for 
-the workflow run.
-"""
-
 before_result_upload = FixtureHook("before_result_upload")
 """Triggered after the result is ready to be uploaded, but before it is actually uploaded."""
 

--- a/virtool_workflow/hooks.py
+++ b/virtool_workflow/hooks.py
@@ -75,22 +75,6 @@ async def _trigger_on_cancelled(error: Exception, scope):
         await on_cancelled.trigger(scope, error)
 
 
-on_load_fixtures = FixtureHook("on_load_fixtures")
-"""
-Triggered after runtime fixtures have been added to the #WorkflowFixtureScope, but
-before the workflow is executed.
-
-Enables modification or injection of specific fixtures before a workflow is executed.
-
-.. code-block:: python
-
-    @on_load_fixtures
-    async def change_fixture_values(fixtures: WorkflowFixtureScope):
-        fixtures["some_fixture"] = SOME_VALUE
-        await fixtures.get_or_instantiate("name_of_some_other_fixture)
-        ...
-"""
-
 on_load_config = FixtureHook("on_load_config")
 """
 Triggered after the config is loaded from the CLI arguments and environment variables. A SimpleNamespace object
@@ -131,7 +115,6 @@ __all__ = [
     "on_finalize",
     "on_finish",
     "on_load_config",
-    "on_load_fixtures",
     "before_result_upload",
     "on_cancelled",
 ]


### PR DESCRIPTION
Removed some hooks that I don't think are used in `virtool-workflow`. If they are not used internally, I would prefer not to expose them to consumers of the library.

Thoughts?