### PR TITLE
Remove class methods on Reads class

### DIFF
--- a/virtool_workflow/analysis/reads.py
+++ b/virtool_workflow/analysis/reads.py
@@ -1,32 +1,18 @@
 from dataclasses import dataclass
-from pathlib import Path
 
 from virtool_workflow import fixture
 from virtool_workflow.abc.caches.analysis_caches import ReadsCache
 from virtool_workflow.analysis.utils import ReadPaths, make_read_paths
-from virtool_workflow.data_model import Sample
 
 
 @dataclass
 class Reads:
-    """Dataclass representing prepared reads for an analysis workflow."""
+    """The prepared reads for an analysis workflow."""
     paired: bool
     min_length: int
     max_length: int
     count: int
     paths: ReadPaths
-
-    @classmethod
-    def from_sample(cls, sample: Sample, path: Path):
-        min_length, max_length = sample.quality["length"]
-        count = sample.quality["count"]
-        return cls(sample.paired, min_length, max_length, count, make_read_paths(path, sample.paired))
-
-    @classmethod
-    def from_quality(cls, quality: dict, paired: bool, path: Path):
-        min_length, max_length = quality["length"]
-        count = quality["count"]
-        return cls(paired, min_length, max_length, count, make_read_paths(path, paired))
 
 
 @fixture
@@ -35,4 +21,12 @@ async def reads(
         reads_cache: ReadsCache = None,
 ):
     """A fixture for accessing trimmed reads for the current sample."""
-    return Reads.from_quality(reads_cache.quality, paired, reads_cache.path)
+    min_length, max_length = reads_cache.quality["length"]
+
+    return Reads(
+        paired,
+        min_length,
+        max_length,
+        reads_cache.quality["count"],
+        make_read_paths(reads_cache.path, paired)
+    )


### PR DESCRIPTION
Simplify `Reads` class my removing class methods.
* Remove `from_sample` method because it is not used.
* Improve class docstring
* Move `from_quality` logic to `reads` fixture.