### PR TITLE
Remove the paired and library_type fixtures

### DIFF
--- a/tests/virtool_workflow/analysis/test_analysis.py
+++ b/tests/virtool_workflow/analysis/test_analysis.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
 from virtool_workflow.abc.caches.analysis_caches import ReadsCache
+from virtool_workflow.analysis.library_types import LibraryType
 from virtool_workflow.analysis.reads import Reads, reads
 from virtool_workflow.analysis.utils import make_read_paths
 from virtool_workflow.caching.local import LocalCacheWriter
+from virtool_workflow.data_model import Sample
 
 
 async def test_get_reads_from_existing_cache(tmpdir, run_in_executor):
@@ -23,7 +25,21 @@ async def test_get_reads_from_existing_cache(tmpdir, run_in_executor):
             "count": 10
         }
 
-    _reads = await reads(reads_cache=reads_cache_writer.cache, paired=False)
+    sample = Sample(
+        id="foo",
+        name="Foo",
+        host="",
+        isolate="",
+        locale="",
+        library_type=LibraryType.other,
+        paired=False,
+        quality=dict(),
+        nuvs=False,
+        pathoscope=False,
+        files=[]
+    )
+
+    _reads = await reads(sample, reads_cache=reads_cache_writer.cache)
 
     assert isinstance(_reads, Reads)
 

--- a/virtool_workflow/analysis/fixtures.py
+++ b/virtool_workflow/analysis/fixtures.py
@@ -1,4 +1,4 @@
-from virtool_workflow.analysis.sample import sample, paired
+from virtool_workflow.analysis.sample import sample
 from virtool_workflow.analysis.subtractions import subtractions
 from virtool_workflow.analysis.hmms import hmms
 from virtool_workflow.analysis.analysis import analysis
@@ -6,7 +6,6 @@ from virtool_workflow.analysis.indexes import indexes
 
 __all__ = [
     "sample",
-    "paired",
     "subtractions",
     "hmms",
     "analysis",

--- a/virtool_workflow/analysis/reads.py
+++ b/virtool_workflow/analysis/reads.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from virtool_workflow import fixture
 from virtool_workflow.abc.caches.analysis_caches import ReadsCache
 from virtool_workflow.analysis.utils import ReadPaths, make_read_paths
+from virtool_workflow.data_model import Sample
 
 
 @dataclass
@@ -17,16 +18,16 @@ class Reads:
 
 @fixture
 async def reads(
-        paired: bool,
-        reads_cache: ReadsCache = None,
+    sample: Sample,
+    reads_cache: ReadsCache = None
 ):
     """A fixture for accessing trimmed reads for the current sample."""
     min_length, max_length = reads_cache.quality["length"]
 
     return Reads(
-        paired,
+        sample.paired,
         min_length,
         max_length,
         reads_cache.quality["count"],
-        make_read_paths(reads_cache.path, paired)
+        make_read_paths(reads_cache.path, sample.paired)
     )

--- a/virtool_workflow/analysis/sample.py
+++ b/virtool_workflow/analysis/sample.py
@@ -23,15 +23,3 @@ async def sample(sample_provider: AbstractSampleProvider, work_path: Path) -> Sa
     sample_.reads_path = read_path
     sample_.read_paths = make_read_paths(read_path, sample_.paired)
     return sample_
-
-
-@fixture
-def paired(sample: Sample) -> bool:
-    """A boolean indicating that the sample data for the current job is paired."""
-    return sample.paired
-
-
-@fixture
-def library_type(sample: Sample) -> LibraryType:
-    """The library type for the sample being analyzed."""
-    return sample.library_type


### PR DESCRIPTION
It is simpler to just use the attributes on the `Sample` object returned by the `sample` fixture.