### PR TITLE
Remove sphinx_rtd_theme import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 #
 import os
 import sys
-import sphinx_rtd_theme
 
 from virtool_workflow.execution.hooks.fixture_hooks import FixtureHook
 


### PR DESCRIPTION
* No longer used in Sphinx `config.py`.
* Blocking Netlify builds.
