### PR TITLE
Use functool.wraps for run_subprocess fixture

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -86,6 +86,12 @@ API Reference
 .. automodule:: virtool_workflow.data_model.analysis
     :members:
 
+``virtool_workflow.execution.run_subprocess``
+=============================================
+
+.. automodule:: virtool_workflow.execution.run_subprocess
+    :members:
+
 ``virtool_workflow.data_model.samples``
 =======================================
 

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -1,5 +1,6 @@
 import asyncio
 import asyncio.subprocess
+import functools
 from logging import getLogger
 from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol, Any, runtime_checkable
 
@@ -12,13 +13,15 @@ RunSubprocessHandler = Callable[[str], Awaitable[None]]
 
 @runtime_checkable
 class RunSubprocess(Protocol):
-    def __call__(self,
-                 command: List[str],
-                 stdout_handler: Optional[RunSubprocessHandler] = None,
-                 stderr_handler: Optional[Callable[[str], Coroutine]] = None,
-                 env: Optional[dict] = None,
-                 cwd: Optional[str] = None,
-                 wait: bool = True) -> Coroutine[Any, Any, asyncio.subprocess.Process]:
+    def __call__(
+            self,
+            command: List[str],
+            stdout_handler: Optional[RunSubprocessHandler] = None,
+            stderr_handler: Optional[Callable[[str], Coroutine]] = None,
+            env: Optional[dict] = None,
+            cwd: Optional[str] = None,
+            wait: bool = True
+    ) -> Coroutine[Any, Any, asyncio.subprocess.Process]:
         ...
 
 
@@ -39,8 +42,16 @@ async def watch_pipe(stream: asyncio.StreamReader, handler: Callable[[bytes], Aw
         await handler(line)
 
 
+
 async def watch_subprocess(process, stdout_handler, stderr_handler):
-    """Watch both stderr and stdout using #watch_pipe."""
+    """
+    Watch both stderr and stdout using :func:`.watch_pipe`.
+
+    :param process: the process to watch
+    :param stdout_handler: a handler function to call with each line received from stdout
+    :param stdout_handler: a handler function to call with each line received from stderr
+
+    """
     coros = [
         watch_pipe(process.stderr, stderr_handler)
     ]
@@ -51,64 +62,68 @@ async def watch_subprocess(process, stdout_handler, stderr_handler):
     await asyncio.gather(*coros)
 
 
+async def _run_subprocess(
+        command: List[str],
+        stdout_handler: Optional[RunSubprocessHandler] = None,
+        stderr_handler: Optional[Callable[[str], Coroutine]] = None,
+        env: Optional[dict] = None,
+        cwd: Optional[str] = None,
+        wait: bool = True,
+) -> asyncio.subprocess.Process:
+    """
+    Run a command as a subprocess and handle stdin and stderr output line-by-line.
+
+    :param command: The command to run as a subprocess.
+    :param stdout_handler: A function to handle stdout lines.
+    :param stderr_handler: A function to handle stderr lines.
+    :param env: Environment variables to set for the subprocess.
+    :param cwd: Current working directory for the subprocess.
+    :param wait: Flag indicating to wait for the subprocess to finish before returning.
+
+    :return
+    """
+    logger.info(f"Running command in subprocess: {' '.join(command)}")
+
+    # Ensure the asyncio child watcher has a reference to the running loop, prevents `process.wait` from hanging.
+    asyncio.get_child_watcher().attach_loop(asyncio.get_running_loop())
+
+    stdout = asyncio.subprocess.PIPE if stdout_handler else asyncio.subprocess.DEVNULL
+
+    if stderr_handler:
+        async def _stderr_handler(line):
+            await stderr_handler(line)
+            logger.info(f"STDERR: {line.rstrip()}")
+    else:
+        async def _stderr_handler(line):
+            logger.info(f"STDERR: {line.rstrip()}")
+
+    process = await asyncio.create_subprocess_exec(
+        *(str(arg) for arg in command),
+        stdout=stdout,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+        cwd=cwd
+    )
+
+    _watch_subprocess = asyncio.create_task(watch_subprocess(process, stdout_handler, _stderr_handler))
+
+    @hooks.on_failure
+    def _terminate_process():
+        if process.returncode is None:
+            process.terminate()
+        _watch_subprocess.cancel()
+
+    if wait:
+        await process.wait()
+
+    return process
+
+
+@functools.wraps(_run_subprocess)
 @fixture
 def run_subprocess() -> RunSubprocess:
     """Fixture to run subprocesses and handle stdin and stderr output line-by-line."""
-
-    async def _run_subprocess(
-            command: List[str],
-            stdout_handler: Optional[RunSubprocessHandler] = None,
-            stderr_handler: Optional[Callable[[str], Coroutine]] = None,
-            env: Optional[dict] = None,
-            cwd: Optional[str] = None,
-            wait: bool = True,
-    ) -> asyncio.subprocess.Process:
-        """
-        Run a command as a subprocess and handle stdin and stderr output line-by-line.
-
-        :param command: The command to run as a subprocess.
-        :param stdout_handler: A function to handle stdout lines.
-        :param stderr_handler: A function to handle stderr lines.
-        :param env: Environment variables to set for the subprocess.
-        :param cwd: Current working directory for the subprocess.
-        :param wait: Flag indicating to wait for the subprocess to finish before returning.
-
-        :return
-        """
-        logger.info(f"Running command in subprocess: {' '.join(command)}")
-
-        # Ensure the asyncio child watcher has a reference to the running loop, prevents `process.wait` from hanging.
-        asyncio.get_child_watcher().attach_loop(asyncio.get_running_loop())
-
-        stdout = asyncio.subprocess.PIPE if stdout_handler else asyncio.subprocess.DEVNULL
-
-        if stderr_handler:
-            async def _stderr_handler(line):
-                await stderr_handler(line)
-                logger.info(f"STDERR: {line.rstrip()}")
-        else:
-            async def _stderr_handler(line):
-                logger.info(f"STDERR: {line.rstrip()}")
-
-        process = await asyncio.create_subprocess_exec(
-            *(str(arg) for arg in command),
-            stdout=stdout,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-            cwd=cwd
-        )
-
-        _watch_subprocess = asyncio.create_task(watch_subprocess(process, stdout_handler, _stderr_handler))
-
-        @hooks.on_failure
-        def _terminate_process():
-            if process.returncode is None:
-                process.terminate()
-            _watch_subprocess.cancel()
-
-        if wait:
-            await process.wait()
-
-        return process
-
     return _run_subprocess
+
+
+run_subprocess.__follow_wrapped__ = False


### PR DESCRIPTION
* Allows fixture do be documented by autodoc
* Declare returned function outside of fixture function as `_run_subprocess`.
* Add to API reference