### PR TITLE
Complete fixture documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosectionlabel", "sphinx.ext.intersphinx"]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.9', None)}
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -98,6 +98,12 @@ API Reference
 .. automodule:: virtool_workflow.data_model.samples
     :members:
 
+``virtool_workflow.data_model.subtractions``
+============================================
+
+.. automodule:: virtool_workflow.data_model.subtractions
+    :members:
+
 ``virtool_workflow.hooks``
 ==========================
 

--- a/virtool_workflow/api/subtractions.py
+++ b/virtool_workflow/api/subtractions.py
@@ -18,9 +18,7 @@ def subtraction_from_json(subtraction_json: dict, path: Path) -> Subtraction:
         subtraction_json["name"],
         subtraction_json["nickname"],
         subtraction_json["count"] if "count" in subtraction_json else None,
-        NucleotideComposition(
-            **subtraction_json["gc"]) if "gc" in subtraction_json else {},
-        subtraction_json["is_host"],
+        NucleotideComposition(**subtraction_json["gc"]) if "gc" in subtraction_json else {},
         path,
     )
 

--- a/virtool_workflow/api/subtractions.py
+++ b/virtool_workflow/api/subtractions.py
@@ -18,7 +18,6 @@ def subtraction_from_json(subtraction_json: dict, path: Path) -> Subtraction:
         subtraction_json["name"],
         subtraction_json["nickname"],
         subtraction_json["count"] if "count" in subtraction_json else None,
-        subtraction_json["deleted"],
         NucleotideComposition(
             **subtraction_json["gc"]) if "gc" in subtraction_json else {},
         subtraction_json["is_host"],

--- a/virtool_workflow/data_model/subtractions.py
+++ b/virtool_workflow/data_model/subtractions.py
@@ -31,7 +31,6 @@ class Subtraction(ABC):
     nickname: str
     count: int
     gc: NucleotideComposition
-    is_host: bool
     path: Path
 
     @property

--- a/virtool_workflow/data_model/subtractions.py
+++ b/virtool_workflow/data_model/subtractions.py
@@ -26,16 +26,58 @@ class NucleotideComposition:
 @dataclass
 class Subtraction(ABC):
     """A dataclass representing a subtraction in Virtool."""
+
     id: str
+    """
+    The unique database ID for the subtraction.
+
+    """
+
     name: str
+    """
+    The user-defined subtraction name.
+
+    Usually the species name (eg. *Malus domestica*).
+
+    """
+
     nickname: str
+    """
+    A user-defined nickname for the subtraction.
+
+    Usually the common name of the species (eg. Apple).
+    """
+
     count: int
+    """
+    The number of distinct sequences in the subtraction dataset.
+
+    For a plant host, this would be the number of chromosomes and plastid genomes.
+
+    """
+
     gc: NucleotideComposition
+    """
+    The nucleotide composition of the subtraction represented as a :class:`.NucleotideComposition` object.
+    """
+
     path: Path
+    """
+    The path to the subtraction directory in the workflow work directory.
+    
+    The subtraction directory contains the FASTA and Bowtie2 files for the subtraction. 
+    """
 
     @property
     def fasta_path(self) -> Path:
-        """The path in the running workflow's work_path to the GZIP-compressed FASTA file for the subtraction"""
+        """
+        The path in the running workflow's work_path to the GZIP-compressed FASTA file for the subtraction.
+
+        eg. ``<work_path>/subtractions/<id>/subtraction.fa.gz``
+
+        :type: :class:`.Path`
+
+        """
         return self.path / "subtraction.fa.gz"
 
     @property
@@ -43,11 +85,15 @@ class Subtraction(ABC):
         """
         The path to Bowtie2 prefix in the the running workflow's work_path
 
-        For example, ``/<work_path>/subtractions/<id>/subtraction`` refers to the Bowtie2 index files:
-            - ``/<work_path>/subtractions/<id>/subtraction.1.bt2``
-            - ``/<work_path>/subtractions/<id>/subtraction.2.bt2``
-            - ``/<work_path>/subtractions/<id>/subtraction.3.bt2``
-            - ``/<work_path>/subtractions/<id>/subtraction.rev.1.bt2``
-            - ``/<work_path>/subtractions/<id>/subtraction.rev.2.bt2``
+        For example, ``<work_path>/subtractions/<id>/subtraction`` refers to the Bowtie2 index files:
+            - ``<work_path>/subtractions/<id>/subtraction.1.bt2``
+            - ``<work_path>/subtractions/<id>/subtraction.2.bt2``
+            - ``<work_path>/subtractions/<id>/subtraction.3.bt2``
+            - ``<work_path>/subtractions/<id>/subtraction.4.bt2``
+            - ``<work_path>/subtractions/<id>/subtraction.rev.1.bt2``
+            - ``<work_path>/subtractions/<id>/subtraction.rev.2.bt2``
+
+        :type: :class:`.Path`
+
         """
-        return f"{self.path}/reference"
+        return self.path / "subtraction"

--- a/virtool_workflow/data_model/subtractions.py
+++ b/virtool_workflow/data_model/subtractions.py
@@ -30,7 +30,6 @@ class Subtraction(ABC):
     name: str
     nickname: str
     count: int
-    deleted: bool
     gc: NucleotideComposition
     is_host: bool
     path: Path

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -80,7 +80,6 @@ async def _run_subprocess(
     :param cwd: Current working directory for the subprocess.
     :param wait: Flag indicating to wait for the subprocess to finish before returning.
 
-    :return
     """
     logger.info(f"Running command in subprocess: {' '.join(command)}")
 


### PR DESCRIPTION
Finish fixture documentation.

* Use `functools.wraps` to make `run_subprocess` fixture work with Sphinx autodoc.
* Use `sphinx.ext.autosectionlabel` for internal linking between headers.
* Remove some unused attributes from the `Subtraction` data model and their usages. Extends docstrings for the parent module of this model.