### PR TITLE
Add sphinx plugin providing special rendering for fixtures.

### DIFF
--- a/docs/_ext/autofixture.py
+++ b/docs/_ext/autofixture.py
@@ -1,0 +1,72 @@
+from sphinx.ext.autodoc import FunctionDocumenter
+from sphinx.domains.python import PyFunction, PyObject
+from sphinx.util.typing import OptionSpec
+from docutils.parsers.rst import directives
+from typing import Any
+import re
+import inspect
+
+
+class FixtureDirective(PyFunction):
+    option_spec: OptionSpec = PyObject.option_spec.copy()
+
+    option_spec.update({
+        'async': directives.flag,
+        'generator': directives.flag,
+    })
+
+    def get_signature_prefix(self, sig: str) -> str:
+        prefix = []
+        if 'async' in self.options:
+            prefix.append('async ')
+
+        if 'generator' in self.options:
+            prefix.append('generator ')
+
+        prefix.append('fixture ')
+
+        return ''.join(prefix)
+
+    def needs_arglist(self) -> bool:
+        return True
+
+class FixtureDocumenter(FunctionDocumenter):
+    objtype = "fixture"
+    directivetype = "fixture"
+    priority = 10 + FunctionDocumenter.priority
+
+    @classmethod
+    def can_document_member(cls,
+                            member: Any, membername: str,
+                            isattr: bool, parent: Any) -> bool:
+        return hasattr(member, 'isfixture')
+
+    
+    def format_args(self, **kwargs: Any) -> str:
+        args = super(FixtureDocumenter, self).format_args(**kwargs)
+
+        return re.sub('\(.*?\)', '(...)', args)
+
+    
+    def add_directive_header(self, sig: str) -> None:
+        sourcename = self.get_sourcename()
+        super().add_directive_header(sig)
+
+        if inspect.iscoroutinefunction(self.object):
+            self.add_line('   :async:', sourcename)
+
+        if inspect.isgeneratorfunction(self.object):
+            self.add_line('   :generator:', sourcename)
+
+
+
+def setup(app):
+    app.setup_extension('sphinx.ext.autodoc')  # Require autodoc extension
+    app.add_autodocumenter(FixtureDocumenter)
+    app.add_directive('py:fixture', FixtureDirective)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/autofixture.rst
+++ b/docs/autofixture.rst
@@ -1,0 +1,10 @@
+``autofixture``
+=================
+
+A custom sphinx extension for rendering fixture documentation.
+
+
+.. autofixture:: showcase.protocol_fixture
+
+
+.. autofixture:: showcase.regular_fixture

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,9 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosectionlabel", "sphinx.ext.intersphinx"]
+sys.path.append(os.path.abspath("./_ext"))
+
+extensions = ["autofixture", "sphinx.ext.autodoc", "sphinx.ext.autosectionlabel", "sphinx.ext.intersphinx"]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.9', None)}
 
@@ -71,9 +73,6 @@ html_css_files = ["custom.css"]
 
 def setup_hook_formatting(app, what, name, obj, options, signature, return_annotation):
     if isinstance(obj, FixtureHook):
-        return None, None
-
-    if getattr(obj, "is_workflow_fixture", False):
         return None, None
 
     return signature, return_annotation

--- a/docs/showcase.py
+++ b/docs/showcase.py
@@ -1,0 +1,28 @@
+from typing import Protocol
+from virtool_workflow import fixture
+from typing import Any
+
+class ReturnProtocol(Protocol):
+    """A showcase return protocol"""
+
+    def __call__(self, a: int, b: str, c: Any, d: str = "default") -> Any:
+        """
+        A function that does something...
+
+        :param a: An argument to the function.
+        :param b: An argument to the function.
+        :param c: An argument to the function.
+
+        :return: Anything, but probably nothing.
+        :raises NotImplementedError: Every time.
+        """
+
+@fixture
+def regular_fixture(a, b, c) -> int:
+    """An example fixture."""
+    ...
+
+
+@fixture(protocol=ReturnProtocol)
+def protocol_fixture(regular_fixture) -> ReturnProtocol:
+    ...

--- a/virtool_workflow/fixtures/providers.py
+++ b/virtool_workflow/fixtures/providers.py
@@ -44,12 +44,32 @@ class FixtureGroup(FixtureProvider, dict):
         if name in self:
             return self[name]
 
-    def fixture(self, func: callable):
+    def fixture(self, func: callable = None, protocol: Protocol = None, hide_params: bool = True):
+        """
+        Add a fixture to this :class`FixtureGroup`
+
+        :param func: The fixture function
+        :param protocol: An optional return protocol for the fixture, used when
+                         rendering documentation for a fixture which returns a function.
+        :param hide_params: Hide the arguments to the fixture when the documentation 
+                          is rendered, defaults to True
+        :return: A fixture function, if :obj:`func` was given, or a decorator to create one.
+        """
+        if func is None:
+            return lambda _func: self.fixture(_func, protocol, hide_params)
+
         if func.__name__.startswith("_"):
             func.__name__ = func.__name__.lstrip("_")
            
         self[func.__name__] = func
+
         func.is_workflow_fixture = True
+
+        if protocol is not None:
+            func.__return_protocol__ = protocol
+
+        func.__hide_params__ = hide_params
+
         return func
 
     def fixtures(self):

--- a/virtool_workflow/fixtures/providers.py
+++ b/virtool_workflow/fixtures/providers.py
@@ -51,7 +51,7 @@ class FixtureGroup(FixtureProvider, dict):
         :param func: The fixture function
         :param protocol: An optional return protocol for the fixture, used when
                          rendering documentation for a fixture which returns a function.
-        :param hide_params: Hide the arguments to the fixture when the documentation 
+        :param hide_params: Hide the arguments to the fixture when the documentation
                           is rendered, defaults to True
         :return: A fixture function, if :obj:`func` was given, or a decorator to create one.
         """

--- a/virtool_workflow/fixtures/workflow_fixture.py
+++ b/virtool_workflow/fixtures/workflow_fixture.py
@@ -11,7 +11,7 @@ workflow_fixtures = FixtureGroup()
 """Global dict containing all defined workflow fixtures."""
 
 
-def fixture(func: Callable):
+def fixture(func: Callable=None, **kwargs):
     """
     Workflow fixtures can be either async or standard functions. They can also be
     generator functions which only yield a single value. Any code after the yield statement
@@ -23,6 +23,8 @@ def fixture(func: Callable):
     :param func: A function returning some value to be used as a workflow fixture
     :return: The unchanged :obj:`func` function.
     """
+    if func is None:
+        return lambda func_: fixture(func_, **kwargs)
     logger.debug(f"Defined a new fixture `{func.__name__}`")
-    return workflow_fixtures.fixture(func)
+    return workflow_fixtures.fixture(func, **kwargs)
 


### PR DESCRIPTION
- Adds `.. fixture` and `.. autofixture` directives.
- Adds improved docs for fixtures that return functions, via Protocol.

## Usage

In `.rst` documentation:
```rst
.. autofixture:: module.fixtures.my_fixture

.. py:fixture:: name(...) -> int
```

### Protocol Fixture

```python
from typing import Protocol
from virtool_workflow import fixture

class Printer(Protocol):
    def __call__(string: str):
        """Print a string"""
        ....

@fixture(protocol=Printer)
def printer():
    ...
    def _printer(string):
         ...

    return _printer
```

The signature of the `Printer` protocol will be added as the return type for
the `printer` fixture. Additionally the docstring for the protocol  will be embedded into
the rendered documentation for `printer`.

The result looks something like this:
![Screenshot from 2021-07-09 14-43-06](https://user-images.githubusercontent.com/16090356/125138766-1d04d580-e0c4-11eb-85aa-79b83e28b888.png)

