### PR TITLE
Ensure `run_subprocess` does not complete until all `stdout` and `stderr` output is read.

### DIFF
--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -120,11 +120,9 @@ communicating with the server.
 
 A utility for starting external programs as new processes.
 
-Returns a function with the following signature:
+.. autofixture:: virtool_workflow.execution.run_subprocess.run_subprocess
 
-.. autofunction:: virtool_workflow.execution.run_subprocess.run_subprocess
-
-The only required argument is ``command``. All others are keyword arguments.
+Example:
 
 .. code-block:: python
 

--- a/virtool_workflow/analysis/hmms.py
+++ b/virtool_workflow/analysis/hmms.py
@@ -56,7 +56,7 @@ async def hmms(hmms_provider: AbstractHMMsProvider, work_path: Path, run_subproc
     if which("hmmpress") is None:
         raise RuntimeError("hmmpress is not installed.")
 
-    process = await run_subprocess(["hmmpress", str(hmms_provider.path/"profiles.hmm")], wait=True)
+    process = await run_subprocess(["hmmpress", str(hmms_provider.path/"profiles.hmm")])
 
     if process.returncode != 0:
         raise RuntimeError("hmmpress command failed")

--- a/virtool_workflow/analysis/indexes.py
+++ b/virtool_workflow/analysis/indexes.py
@@ -201,7 +201,7 @@ class Index(data_model.Index):
             str(path),
         ]
 
-        await self._run_subprocess(command, wait=True)
+        await self._run_subprocess(command)
 
         return fasta_path, lengths
 

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -2,7 +2,7 @@ import asyncio
 import asyncio.subprocess
 import functools
 from logging import getLogger
-from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol, Any, runtime_checkable
+from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol, Any
 
 from virtool_workflow import fixture, hooks
 
@@ -11,7 +11,6 @@ logger = getLogger(__name__)
 RunSubprocessHandler = Callable[[str], Awaitable[None]]
 
 
-@runtime_checkable
 class RunSubprocess(Protocol):
     def __call__(
             self,

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -1,8 +1,7 @@
 import asyncio
 import asyncio.subprocess
-import functools
 from logging import getLogger
-from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol, Any
+from typing import Optional, Callable, Awaitable, List, Coroutine, Protocol
 
 from virtool_workflow import fixture, hooks
 
@@ -20,25 +19,31 @@ class LineOutputHandler(Protocol):
 
 
 class RunSubprocess(Protocol):
-    def __call__(
+    async def __call__(
             self,
             command: List[str],
             stdout_handler: Optional[LineOutputHandler] = None,
-            stderr_handler: Optional[Callable[[str], Coroutine]] = None,
+            stderr_handler: Optional[LineOutputHandler] = None,
             env: Optional[dict] = None,
             cwd: Optional[str] = None,
             wait: bool = True
-    ) -> Coroutine[Any, Any, asyncio.subprocess.Process]:
+    ) -> asyncio.subprocess.Process:
         """
-        Run a command as a subprocess and handle stdin and stderr output line-by-line.
+        Run a shell command in a subprocess.
 
-        :param command: The command to run as a subprocess.
-        :param stdout_handler: A function to handle stdout lines.
-        :param stderr_handler: A function to handle stderr lines.
-        :param env: Environment variables to set for the subprocess.
-        :param cwd: Current working directory for the subprocess.
-        :param wait: Flag indicating to wait for the subprocess to finish before returning.
+        :param command: A shell command, as a list of strings including the program name and arguments
+        :type command: List[str]
+        :param stdout_handler: A function to handle stdout output line by line
+        :type stdout_handler: Optional[LineOutputHandler], optional
+        :param stderr_handler: A function to handle stderr output line by line
+        :type stderr_handler: Optional[LineOutputHandler], optional
+        :param env: environment variables which should be available to the subprocess
+        :type env: Optional[dict], optional
+        :param cwd: The current working directory for the subprocess
+        :type cwd: Optional[str], optional
 
+        :return: An :class:`asyncio.subprocess.Process` instance
+        :rtype: asyncio.subprocess.Process
         """
         ...
 
@@ -88,17 +93,7 @@ async def _run_subprocess(
         cwd: Optional[str] = None,
         wait: bool = True,
 ) -> asyncio.subprocess.Process:
-    """
-    Run a command as a subprocess and handle stdin and stderr output line-by-line.
-
-    :param command: The command to run as a subprocess.
-    :param stdout_handler: A function to handle stdout lines.
-    :param stderr_handler: A function to handle stderr lines.
-    :param env: Environment variables to set for the subprocess.
-    :param cwd: Current working directory for the subprocess.
-    :param wait: Flag indicating to wait for the subprocess to finish before returning.
-
-    """
+    """An implementation of :class:`RunSubprocess` using `asyncio.subprocess`."""
     logger.info(f"Running command in subprocess: {' '.join(command)}")
 
     # Ensure the asyncio child watcher has a reference to the running loop, prevents `process.wait` from hanging.
@@ -136,11 +131,7 @@ async def _run_subprocess(
     return process
 
 
-@functools.wraps(_run_subprocess)
-@fixture
+@fixture(protocol=RunSubprocess)
 def run_subprocess() -> RunSubprocess:
     """Fixture to run subprocesses and handle stdin and stderr output line-by-line."""
     return _run_subprocess
-
-
-run_subprocess.__follow_wrapped__ = False

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -29,6 +29,17 @@ class RunSubprocess(Protocol):
             cwd: Optional[str] = None,
             wait: bool = True
     ) -> Coroutine[Any, Any, asyncio.subprocess.Process]:
+        """
+        Run a command as a subprocess and handle stdin and stderr output line-by-line.
+
+        :param command: The command to run as a subprocess.
+        :param stdout_handler: A function to handle stdout lines.
+        :param stderr_handler: A function to handle stderr lines.
+        :param env: Environment variables to set for the subprocess.
+        :param cwd: Current working directory for the subprocess.
+        :param wait: Flag indicating to wait for the subprocess to finish before returning.
+
+        """
         ...
 
 

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -8,14 +8,22 @@ from virtool_workflow import fixture, hooks
 
 logger = getLogger(__name__)
 
-RunSubprocessHandler = Callable[[str], Awaitable[None]]
+class LineOutputHandler(Protocol):
+    async def __Call__(self, line: str):
+        """
+        Handle input from stdin, or stderr, line by line.
+
+        :param line: A line of output from the stream.
+        :type line: str
+        """
+        ...
 
 
 class RunSubprocess(Protocol):
     def __call__(
             self,
             command: List[str],
-            stdout_handler: Optional[RunSubprocessHandler] = None,
+            stdout_handler: Optional[LineOutputHandler] = None,
             stderr_handler: Optional[Callable[[str], Coroutine]] = None,
             env: Optional[dict] = None,
             cwd: Optional[str] = None,
@@ -63,7 +71,7 @@ async def watch_subprocess(process, stdout_handler, stderr_handler):
 
 async def _run_subprocess(
         command: List[str],
-        stdout_handler: Optional[RunSubprocessHandler] = None,
+        stdout_handler: Optional[LineOutputHandler] = None,
         stderr_handler: Optional[Callable[[str], Coroutine]] = None,
         env: Optional[dict] = None,
         cwd: Optional[str] = None,

--- a/virtool_workflow/execution/run_subprocess.py
+++ b/virtool_workflow/execution/run_subprocess.py
@@ -23,10 +23,10 @@ class RunSubprocess(Protocol):
     async def __call__(
             self,
             command: List[str],
-            stdout_handler: Optional[LineOutputHandler] = None,
-            stderr_handler: Optional[LineOutputHandler] = None,
-            env: Optional[dict] = None,
-            cwd: Optional[str] = None,
+            stdout_handler: LineOutputHandler = None,
+            stderr_handler: LineOutputHandler = None,
+            env: dict = None,
+            cwd: str = None,
     ) -> asyncio.subprocess.Process:
         """
         Run a shell command in a subprocess.


### PR DESCRIPTION
- Ensures that `watch_subprocess` is awaited. 
- Removes the `wait` parameter as it was unused, and is incompatable with the other changes made.
- Update the fixture docs to use `.. autofixture` directive


