### PR TITLE
Fixture Improvements.

### DIFF
--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,9 +1,11 @@
 """Pytest style fixtures for use in python applications."""
-from ._fixture import Fixture, FixtureValue, fixture_context, get_fixtures
+from ._fixture import (Fixture, FixtureValue, fixture_context, get_fixtures,
+                       runs_in_new_fixture_context)
 
 __all__ = [
     "fixture_context",
     "Fixture",
     "FixtureValue",
     "get_fixtures",
+    "runs_in_new_fixture_context",
 ]

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,9 +1,10 @@
 """Pytest style fixtures for use in python applications."""
-from ._fixture import (Fixture, FixtureValue, fixture_context, get_fixtures,
-                       runs_in_new_fixture_context)
+from ._fixture import (Fixture, FixtureValue, fixture, fixture_context,
+                       get_fixtures, runs_in_new_fixture_context)
 
 __all__ = [
     "fixture_context",
+    "fixture",
     "Fixture",
     "FixtureValue",
     "get_fixtures",

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,11 +1,13 @@
 """Pytest style fixtures for use in python applications."""
 from ._fixture import (Fixture, FixtureValue, fixture, fixture_context,
                        get_fixtures, runs_in_new_fixture_context)
+from ._scope import FixtureScope
 
 __all__ = [
     "fixture_context",
     "fixture",
     "Fixture",
+    "FixtureScope",
     "FixtureValue",
     "get_fixtures",
     "runs_in_new_fixture_context",

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,1 +1,9 @@
 """Pytest style fixtures for use in python applications."""
+from ._fixture import Fixture, FixtureValue, fixture_context, get_fixtures
+
+__all__ = [
+    "fixture_context",
+    "Fixture",
+    "FixtureValue",
+    "get_fixtures",
+]

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest style fixtures for use in python applications."""

--- a/fixtures/_fixture.py
+++ b/fixtures/_fixture.py
@@ -1,0 +1,19 @@
+from typing import Any, NewType, Protocol, runtime_checkable
+
+FixtureValue = NewType('FixtureValue', Any)
+"""A return value from a :class:`Fixture` callable."""
+
+
+@runtime_checkable
+class Fixture(Protocol):
+    """
+    A Protocol formally defining any attributes which are 
+    to a fixture function via @:func:`fixture`.
+
+    Enables `isinstance(function, Fixture)` checks to be made.
+
+    """
+    __is_fixture__: bool = True
+
+    async def __call__(self, *args, **kwargs) -> FixtureValue:
+        ...

--- a/fixtures/_fixture.py
+++ b/fixtures/_fixture.py
@@ -1,4 +1,8 @@
-from typing import Any, NewType, Protocol, runtime_checkable
+import inspect
+from functools import wraps
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Dict, NewType, Protocol, runtime_checkable
 
 FixtureValue = NewType('FixtureValue', Any)
 """A return value from a :class:`Fixture` callable."""
@@ -13,7 +17,70 @@ class Fixture(Protocol):
     Enables `isinstance(function, Fixture)` checks to be made.
 
     """
+    __name__: str
     __is_fixture__: bool = True
 
     async def __call__(self, *args, **kwargs) -> FixtureValue:
         ...
+
+
+_fixtures = ContextVar("fixtures")
+
+
+def get_fixtures():
+    """get the fixtures dictionary for the current context."""
+    try:
+        return _fixtures.get()
+    except LookupError:
+        _fixtures.set({})
+        return _fixtures.get()
+
+
+@contextmanager
+def fixture_context(*fixtures: Fixture, copy_context=True) -> Dict[str, Fixture]:
+    """
+    Enter a new fixture context.
+
+    Any fixtures added within the `with` block will no not be available outside of it.
+
+    :param fixtures: Any fixtures which should be included in the context.
+                     If a fixture with the same name is already present, the 
+                     new fixture will be used instead.
+    :param copy_context: Copy the fixtures dict from the current context, defaults to True.
+                     
+
+    :yield: A dictionary mapping fixture names to :class:`Fixture` functions.
+    """
+    if copy_context is True:
+        current_fixtures = get_fixtures()
+        _fixtures_copy = current_fixtures.copy()
+    else:
+        _fixtures_copy = {}
+
+    for fixture in fixtures:
+        _fixtures_copy[fixture.__name__] = fixture
+
+    token = _fixtures.set(_fixtures_copy)
+
+    try:
+        yield _fixtures.get()
+    finally:
+        _fixtures.reset(token)
+
+
+def runs_in_new_fixture_context(function: callable):
+    """Decorator which causes the function to be executed in a new fixture context."""
+    if inspect.iscoroutinefunction(function):
+        @wraps(function)
+        async def _in_new_context(*args, **kwargs):
+            with fixture_context():
+                return await function(*args, **kwargs)
+    else:
+        @wraps(function)
+        def _in_new_context(*args, **kwargs):
+            with fixture_context():
+                return function(*args, **kwargs)
+
+    return _in_new_context
+
+

--- a/fixtures/_fixture.py
+++ b/fixtures/_fixture.py
@@ -2,7 +2,7 @@ import inspect
 from functools import wraps
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Dict, NewType, Protocol, runtime_checkable, Type
+from typing import Any, Dict, NewType, Protocol, runtime_checkable
 
 FixtureValue = NewType('FixtureValue', Any)
 """A return value from a :class:`Fixture` callable."""
@@ -11,7 +11,7 @@ FixtureValue = NewType('FixtureValue', Any)
 @runtime_checkable
 class Fixture(Protocol):
     """
-    A Protocol formally defining any attributes which are 
+    A Protocol formally defining any attributes which are
     added to a fixture function via @:func:`fixture`.
 
     Enables `isinstance(function, Fixture)` checks to be made.
@@ -22,7 +22,7 @@ class Fixture(Protocol):
     __hide_params__: bool
 
     async def __call__(self, *args, **kwargs) -> FixtureValue:
-        ...
+        raise NotImplementedError()
 
 
 _fixtures = ContextVar("fixtures")
@@ -32,7 +32,7 @@ def get_fixtures() -> Dict[str, Fixture]:
     """
     get the fixtures dictionary for the current context.
 
-    If it does not exist, a new dictionary is created. 
+    If it does not exist, a new dictionary is created.
     """
     try:
         return _fixtures.get()
@@ -49,10 +49,10 @@ def fixture_context(*fixtures: Fixture, copy_context=True) -> Dict[str, Fixture]
     Any fixtures created within the `with` block will not be available outside of it.
 
     :param fixtures: Any fixtures which should be included in the context.
-                     If a fixture with the same name is already present, the 
+                     If a fixture with the same name is already present, the
                      new fixture will be used instead.
     :param copy_context: Copy the fixtures dict from the current context, defaults to True.
-                     
+
 
     :yield: A dictionary mapping fixture names to :class:`Fixture` functions.
     """
@@ -115,4 +115,3 @@ def fixture(function: callable = None, protocol: Protocol = None, hide_params: b
     fixtures[function.__name__] = function
 
     return function
-

--- a/fixtures/_fixture.py
+++ b/fixtures/_fixture.py
@@ -12,7 +12,7 @@ FixtureValue = NewType('FixtureValue', Any)
 class Fixture(Protocol):
     """
     A Protocol formally defining any attributes which are 
-    to a fixture function via @:func:`fixture`.
+    added to a fixture function via @:func:`fixture`.
 
     Enables `isinstance(function, Fixture)` checks to be made.
 
@@ -28,8 +28,12 @@ class Fixture(Protocol):
 _fixtures = ContextVar("fixtures")
 
 
-def get_fixtures():
-    """get the fixtures dictionary for the current context."""
+def get_fixtures() -> Dict[str, Fixture]:
+    """
+    get the fixtures dictionary for the current context.
+
+    If it does not exist, a new dictionary is created. 
+    """
     try:
         return _fixtures.get()
     except LookupError:
@@ -42,7 +46,7 @@ def fixture_context(*fixtures: Fixture, copy_context=True) -> Dict[str, Fixture]
     """
     Enter a new fixture context.
 
-    Any fixtures added within the `with` block will no not be available outside of it.
+    Any fixtures created within the `with` block will not be available outside of it.
 
     :param fixtures: Any fixtures which should be included in the context.
                      If a fixture with the same name is already present, the 

--- a/fixtures/_fixture.py
+++ b/fixtures/_fixture.py
@@ -68,19 +68,21 @@ def fixture_context(*fixtures: Fixture, copy_context=True) -> Dict[str, Fixture]
         _fixtures.reset(token)
 
 
-def runs_in_new_fixture_context(function: callable):
+def runs_in_new_fixture_context(*fixtures, copy_context=True):
     """Decorator which causes the function to be executed in a new fixture context."""
-    if inspect.iscoroutinefunction(function):
-        @wraps(function)
-        async def _in_new_context(*args, **kwargs):
-            with fixture_context():
-                return await function(*args, **kwargs)
-    else:
-        @wraps(function)
-        def _in_new_context(*args, **kwargs):
-            with fixture_context():
-                return function(*args, **kwargs)
+    def _deco(function: callable):
+        if inspect.iscoroutinefunction(function):
+            @wraps(function)
+            async def _in_new_context(*args, **kwargs):
+                with fixture_context(*fixtures, copy_context=copy_context):
+                    return await function(*args, **kwargs)
+        else:
+            @wraps(function)
+            def _in_new_context(*args, **kwargs):
+                with fixture_context(*fixtures, copy_context=copy_context):
+                    return function(*args, **kwargs)
 
-    return _in_new_context
+        return _in_new_context
+    return _deco
 
 

--- a/fixtures/_scope.py
+++ b/fixtures/_scope.py
@@ -1,9 +1,13 @@
+
+import asyncio
 import inspect
 from collections import UserDict
-from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
-from typing import Union
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager, suppress
+from functools import wraps
+from typing import Any, AnyStr, Dict, Union
 
-from ._fixture import Fixture
+from ._fixture import Fixture, get_fixtures
+from .errors import FixtureBindingError, FixtureNotFound
 
 
 class FixtureScope(UserDict):
@@ -75,9 +79,191 @@ class FixtureScope(UserDict):
         return function(*args, **kwargs)
 
 
+    @property
+    def available(self) -> Dict[str, Any]:
+        """A dict of all available fixtures."""
+        fixtures = get_fixtures()
+        return dict(fixtures, **self)
 
-    async def instantiate(self, function: Union[callable, Fixture]):
-        ...
+
+    @staticmethod
+    def _get_arg_spec(function, follow_wrapped=False) -> inspect.FullArgSpec:
+        """
+        Get the arg spec for a function.
+
+        :param function: A function.
+        :param follow_wrapped: Follow `__wrapped__`, defaults to False.
+
+        :return: A :class:`inspect.FullArgSpec`
+        """
+        if follow_wrapped:
+            function = inspect.unwrap(function)
+        return inspect.getfullargspec(function)
+
+
+    @staticmethod
+    def _make_future(value: Any) -> asyncio.Future:
+        """Create a future from a variable."""
+        future = asyncio.Future()
+        future.set_result(value)
+        return future
+
+
+    async def bind(
+        self,
+        function: Union[callable, Fixture],
+        follow_wrapped: bool = False,
+        **kwargs: Any,
+    ) -> Union[callable, Fixture]:
+        """
+        Instantiate fixtures as needed based on the signature of
+        `function`. Wrap `function` to pass the fixture values as 
+        parameters where needed.
+
+        This function will try to get a value for each key with the following priority:
+
+            :first: 
+                Values from `**kwargs`. if one is present for the given key then 
+                the corresponding fixture would not be instantiated.
+            
+            :second:
+                If no value is present in `**kwargs` the fixture will be instantiated
+                and it's return value will be used.
+
+            :third:
+                Lastly, if the fixture cannot be instantiated, the default value for the
+                parameter (on the fixture function) will be used if it exists.
+
+        :param function: The function to bind fixtures to.
+        :param follow_wrapped: Use the signature of the wrapped function
+                               instead of the outer function, defaults to False
+        :param kwargs: Additional keyword arguments to bind to the function.
+                       This will be used instead of the fixture value when there
+                       is a name collision.
+        :raise FixtureBindingError: When a required fixture cannot be found or instantiated.
+
+        :return: A function wrapping `function` which does not require arguments.
+                 If arguments are given they will overwrite the bound fixture values.
+        """
+        argspec = self._get_arg_spec(function, follow_wrapped)
+
+        if argspec.varargs is not None or argspec.varkw is not None:
+            raise FixtureBindingError(
+                function, argspec.varargs,
+                reason="Binding fixtures to `*args` or `**kwargs` is not supported."
+            )
+
+        if len(argspec.args) == 0:
+            return function
+
+        if argspec.defaults:
+            args_with_default = argspec.args[-len(argspec.defaults):]
+            defaults = {key: value for key, value in zip(args_with_default, argspec.defaults)}
+        else:
+            defaults = {}
+
+        keywordargs = {}
+        for key in argspec.args:
+            with suppress(KeyError):
+                keywordargs[key] = kwargs[key]
+                continue
+
+            try:
+                keywordargs[key] = await self.instantiate_by_key(key)
+            except Exception as e:
+                if key in defaults:
+                    keywordargs[key] = defaults[key]
+                    continue
+
+                raise FixtureBindingError(
+                    function, key, 
+                    reason=f"Could not instantiate `{key}` due to {e.__class__.__name__}"
+                ) from e
+
+
+        if inspect.iscoroutinefunction(function):
+            @wraps(function)
+            async def _bound(*args, **kwargs):
+                keywordargs.update(kwargs)
+                return await function(*args, **keywordargs)
+        else:
+            @wraps(function)
+            def _bound(*args, **kwargs):
+                if args or kwargs:
+                    # Since `keywordargs` is stored in the closure
+                    # updates to it will persist between calls
+                    _keywordargs = keywordargs.copy()
+                else:
+                    _keywordargs = keywordargs
+
+                # Support using keyword arguments when calling `_bound`
+                _keywordargs.update(kwargs)
+
+                # Support using positional arguments when calling `_bound`
+                if args:
+                    # Remove supplied args from the `keywordargs`
+                    arg_names = argspec.args[:len(args)]
+                    for name in arg_names:
+                        del _keywordargs[name]
+                return function(*args, **_keywordargs)
+
+        return _bound
+
+
+    async def instantiate_by_key(self, key: str, *args, **kwargs) -> Any:
+        """Instantiate a fixture by it's name."""
+        with suppress(KeyError):
+            return self[key]
+
+        fixtures = get_fixtures()
+        try:
+            fixture = fixtures[key]
+        except KeyError: 
+            raise FixtureNotFound(key, self)
+
+        return await self.instantiate(fixture, *args, **kwargs)
+
+
+
+    async def get_or_instantiate(
+        self,
+        fixture: Union[str, callable, Fixture],
+        *args: Any, 
+        **kwargs: Any, 
+    ):
+        """Instantiate a fixture by name, or directly."""
+        if isinstance(fixture, AnyStr):
+            return self.instantiate_by_key(fixture, *args, **kwargs)
+        else:
+            return self.instantiate(fixture, *args, **kwargs)
+
+
+    async def instantiate(self, fixture: Fixture, *args, **kwargs):
+        """
+        Instantiate a given fixture and add it to the scope.
+
+        Recursively bind parameters of the function as required.
+
+        :param function: The function/fixture to instantiate.
+        :return: The fixture's value.
+        """
+        with suppress(KeyError):
+            return self[fixture.__name__]
+
+        try:
+            value = await self._instantiate(fixture, *args, **kwargs)
+        except TypeError as e:
+            if "missing" not in str(e):
+                raise
+
+            value = await self.instantiate(await self.bind(fixture, follow_wrapped=True), *args, **kwargs)
+
+
+        self[fixture.__name__] = value
+
+        return value
+
+
 
 
 

--- a/fixtures/_scope.py
+++ b/fixtures/_scope.py
@@ -13,18 +13,11 @@ from .errors import FixtureBindingError, FixtureNotFound
 class FixtureScope(UserDict):
     """
     A container for fixture values. It functions as a regular Dict[str, Any]
-    with additional method for binding fixture values.
+    with additional methods for binding fixture values.
 
     It also acts as an async context manager handling generator
     and async generator fixtures.
     """
-    def __init__(self, *args, **instances):
-        super(FixtureScope, self).__init__(*args, **instances)
-
-        self._generators, self._async_generators = [], []
-
-        self.open, self.closed = False, False
-
     async def __aenter__(self):
         """
         Creates a :class:`AsyncExitStack` where context managers

--- a/fixtures/_scope.py
+++ b/fixtures/_scope.py
@@ -25,8 +25,7 @@ class FixtureScope(UserDict):
 
         :return: This instance of :class:`FixtureScope`.
         """
-        self._exit_stack = AsyncExitStack()
-        self.exit_stack = await self._exit_stack.__aenter__()
+        self.exit_stack = await AsyncExitStack().__aenter__()
         return self
 
 
@@ -35,7 +34,7 @@ class FixtureScope(UserDict):
         Close this scope, ensuring that all generator and async generator
         fixtures are completed.
         """
-        await self._exit_stack.__aexit__(*args)
+        await self.exit_stack.__aexit__(*args)
 
     async def _instantiate(self, function: Union[callable, Fixture], *args, **kwargs):
         """

--- a/fixtures/_scope.py
+++ b/fixtures/_scope.py
@@ -1,0 +1,44 @@
+from collections import UserDict
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Union
+from ._fixture import Fixture
+
+class FixtureScope(UserDict):
+    """
+    A container for fixture values. It functions as a regular Dict[str, Any]
+    with additional method for binding fixture values.
+
+    It also acts as an async context manager handling generator
+    and async generator fixtures.
+    """
+    def __init__(self, *args, **instances):
+        super(FixtureScope, self).__init__(*args, **instances)
+
+        self._generators, self._async_generators = [], []
+
+        self.open, self.closed = False, False
+
+    async def __aenter__(self):
+        """
+        Creates a :class:`AsyncExitStack` where context managers
+        can be added to handle generator and async generator fixtures.
+
+        :return: This instance of :class:`FixtureScope`.
+        """
+        self._exit_stack = AsyncExitStack()
+        return self
+
+
+    async def __aexit__(self, *args):
+        """
+        Close this scope, ensuring that all generator and async generator
+        fixtures are completed.
+        """
+        self._exit_stack.__aexit__(*args)
+
+    async def instantiate(function: Union[callable, Fixture]):
+        ...
+
+
+
+

--- a/fixtures/_scope.py
+++ b/fixtures/_scope.py
@@ -1,12 +1,13 @@
 
-import asyncio
 import inspect
 from collections import UserDict
-from contextlib import AsyncExitStack, asynccontextmanager, contextmanager, suppress
+from contextlib import (AsyncExitStack, asynccontextmanager, contextmanager,
+                        suppress)
 from functools import wraps
 from typing import Any, AnyStr, Dict, Union
 
 from ._fixture import Fixture, get_fixtures
+from ._utils import get_arg_spec, get_defaults
 from .errors import FixtureBindingError, FixtureNotFound
 
 
@@ -28,12 +29,14 @@ class FixtureScope(UserDict):
         self.exit_stack = await AsyncExitStack().__aenter__()
         return self
 
-
     async def __aexit__(self, *args):
         """
-        Close this scope, ensuring that all generator and async generator
-        fixtures are completed.
+        Close the :class:FixtureScope.
+
+            1. Remove all references to fixture values.
+            2. Close the exit stack, ensuring that generator fixtures are closed out.
         """
+        self.clear()
         await self.exit_stack.__aexit__(*args)
 
     async def _instantiate(self, function: Union[callable, Fixture], *args, **kwargs):
@@ -57,19 +60,20 @@ class FixtureScope(UserDict):
         :return: The return (or yield) value of `function`.
         """
         if inspect.isasyncgenfunction(function):
-            ctx_manager = asynccontextmanager(function)
-            return await self.exit_stack.enter_async_context(ctx_manager(*args, **kwargs))
+            return await self.exit_stack.enter_async_context(
+                asynccontextmanager(function)(*args, **kwargs)
+            )
 
         if inspect.isgeneratorfunction(function):
-            ctx_manager = contextmanager(function)
-            return self.exit_stack.enter_context(ctx_manager(*args, **kwargs))
-        
+            return self.exit_stack.enter_context(
+                contextmanager(function)(*args, **kwargs)
+            )
+
         if inspect.iscoroutinefunction(function):
             return await function(*args, **kwargs)
 
-        # Must be a synchronous function.
+        # Must be a synchronous function..
         return function(*args, **kwargs)
-
 
     @property
     def available(self) -> Dict[str, Any]:
@@ -77,29 +81,49 @@ class FixtureScope(UserDict):
         fixtures = get_fixtures()
         return dict(fixtures, **self)
 
-
-    @staticmethod
-    def _get_arg_spec(function, follow_wrapped=False) -> inspect.FullArgSpec:
+    def _bind(
+        self,
+        function: callable,
+        argspec: inspect.FullArgSpec,
+        values: dict,
+    ) -> callable:
         """
-        Get the arg spec for a function.
+        Bind values to function parameters.
 
-        :param function: A function.
-        :param follow_wrapped: Follow `__wrapped__`, defaults to False.
+        :param function: The function to bind.
+        :param argspec: The argspec for the function, obtained 
+                        via :func:`inspect.getfullargspec`.
+        :param values: Key value pairs to bind to the function.
 
-        :return: A :class:`inspect.FullArgSpec`
+        :return: The bound function.
         """
-        if follow_wrapped:
-            function = inspect.unwrap(function)
-        return inspect.getfullargspec(function)
+        if inspect.iscoroutinefunction(function):
+            @wraps(function)
+            async def _bound(*args, **kwargs):
+                values.update(kwargs)
+                return await function(*args, **values)
+        else:
+            @wraps(function)
+            def _bound(*args, **kwargs):
+                if args or kwargs:
+                    # Since `values` is stored in the closure
+                    # updates to it will persist between calls
+                    _values = values.copy()
+                else:
+                    _values = values
 
+                # Support using keyword arguments when calling `_bound`
+                _values.update(kwargs)
 
-    @staticmethod
-    def _make_future(value: Any) -> asyncio.Future:
-        """Create a future from a variable."""
-        future = asyncio.Future()
-        future.set_result(value)
-        return future
+                # Support using positional arguments when calling `_bound`
+                if args:
+                    # Remove supplied args from the `values`
+                    arg_names = argspec.args[:len(args)]
+                    for name in arg_names:
+                        del _values[name]
+                return function(*args, **_values)
 
+        return _bound
 
     async def bind(
         self,
@@ -117,13 +141,13 @@ class FixtureScope(UserDict):
             :first: 
                 Values from `**kwargs`. if one is present for the given key then 
                 the corresponding fixture would not be instantiated.
-            
+
             :second:
                 If no value is present in `**kwargs` the fixture will be instantiated
                 and it's return value will be used.
 
             :third:
-                Lastly, if the fixture cannot be instantiated, the default value for the
+                If the fixture cannot be instantiated, the default value for the
                 parameter (on the fixture function) will be used if it exists.
 
         :param function: The function to bind fixtures to.
@@ -137,7 +161,7 @@ class FixtureScope(UserDict):
         :return: A function wrapping `function` which does not require arguments.
                  If arguments are given they will overwrite the bound fixture values.
         """
-        argspec = self._get_arg_spec(function, follow_wrapped)
+        argspec = get_arg_spec(function, follow_wrapped)
 
         if argspec.varargs is not None or argspec.varkw is not None:
             raise FixtureBindingError(
@@ -148,59 +172,25 @@ class FixtureScope(UserDict):
         if len(argspec.args) == 0:
             return function
 
-        if argspec.defaults:
-            args_with_default = argspec.args[-len(argspec.defaults):]
-            defaults = {key: value for key, value in zip(args_with_default, argspec.defaults)}
-        else:
-            defaults = {}
+        defaults = get_defaults(argspec)
 
-        keywordargs = {}
         for key in argspec.args:
-            with suppress(KeyError):
-                keywordargs[key] = kwargs[key]
+            if key in kwargs:
                 continue
 
             try:
-                keywordargs[key] = await self.instantiate_by_key(key)
+                kwargs[key] = await self.instantiate_by_key(key)
             except Exception as e:
                 if key in defaults:
-                    keywordargs[key] = defaults[key]
+                    kwargs[key] = defaults[key]
                     continue
 
                 raise FixtureBindingError(
-                    function, key, 
+                    function, key,
                     reason=f"Could not instantiate `{key}` due to {e.__class__.__name__}"
                 ) from e
 
-
-        if inspect.iscoroutinefunction(function):
-            @wraps(function)
-            async def _bound(*args, **kwargs):
-                keywordargs.update(kwargs)
-                return await function(*args, **keywordargs)
-        else:
-            @wraps(function)
-            def _bound(*args, **kwargs):
-                if args or kwargs:
-                    # Since `keywordargs` is stored in the closure
-                    # updates to it will persist between calls
-                    _keywordargs = keywordargs.copy()
-                else:
-                    _keywordargs = keywordargs
-
-                # Support using keyword arguments when calling `_bound`
-                _keywordargs.update(kwargs)
-
-                # Support using positional arguments when calling `_bound`
-                if args:
-                    # Remove supplied args from the `keywordargs`
-                    arg_names = argspec.args[:len(args)]
-                    for name in arg_names:
-                        del _keywordargs[name]
-                return function(*args, **_keywordargs)
-
-        return _bound
-
+        return self._bind(function, argspec, kwargs)
 
     async def instantiate_by_key(self, key: str, *args, **kwargs) -> Any:
         """Instantiate a fixture by it's name."""
@@ -210,25 +200,22 @@ class FixtureScope(UserDict):
         fixtures = get_fixtures()
         try:
             fixture = fixtures[key]
-        except KeyError: 
+        except KeyError:
             raise FixtureNotFound(key, self)
 
         return await self.instantiate(fixture, *args, **kwargs)
 
-
-
     async def get_or_instantiate(
         self,
         fixture: Union[str, callable, Fixture],
-        *args: Any, 
-        **kwargs: Any, 
+        *args: Any,
+        **kwargs: Any,
     ):
         """Instantiate a fixture by name, or directly."""
         if isinstance(fixture, AnyStr):
             return self.instantiate_by_key(fixture, *args, **kwargs)
         else:
             return self.instantiate(fixture, *args, **kwargs)
-
 
     async def instantiate(self, fixture: Fixture, *args, **kwargs):
         """
@@ -250,13 +237,6 @@ class FixtureScope(UserDict):
 
             value = await self.instantiate(await self.bind(fixture, follow_wrapped=True), *args, **kwargs)
 
-
         self[fixture.__name__] = value
 
         return value
-
-
-
-
-
-

--- a/fixtures/_scope.py
+++ b/fixtures/_scope.py
@@ -51,7 +51,7 @@ class FixtureScope(UserDict):
             - `function` is a (synchronous) generator function.
 
         In the case of generator (or async generator) functions,
-        they will be converted into async context managers via :mod:`contextlib` 
+        they will be converted into async context managers via :mod:`contextlib`
         and added to the exit stack.
 
         :param args: arguments to forward to the function.
@@ -81,8 +81,8 @@ class FixtureScope(UserDict):
         fixtures = get_fixtures()
         return dict(fixtures, **self)
 
+    @staticmethod
     def _bind(
-        self,
         function: callable,
         argspec: inspect.FullArgSpec,
         values: dict,
@@ -91,7 +91,7 @@ class FixtureScope(UserDict):
         Bind values to function parameters.
 
         :param function: The function to bind.
-        :param argspec: The argspec for the function, obtained 
+        :param argspec: The argspec for the function, obtained
                         via :func:`inspect.getfullargspec`.
         :param values: Key value pairs to bind to the function.
 
@@ -133,13 +133,13 @@ class FixtureScope(UserDict):
     ) -> Union[callable, Fixture]:
         """
         Instantiate fixtures as needed based on the signature of
-        `function`. Wrap `function` to pass the fixture values as 
+        `function`. Wrap `function` to pass the fixture values as
         parameters where needed.
 
         This function will try to get a value for each key with the following priority:
 
-            :first: 
-                Values from `**kwargs`. if one is present for the given key then 
+            :first:
+                Values from `**kwargs`. if one is present for the given key then
                 the corresponding fixture would not be instantiated.
 
             :second:

--- a/fixtures/_utils.py
+++ b/fixtures/_utils.py
@@ -1,0 +1,25 @@
+import inspect
+
+
+def get_defaults(argspec: inspect.FullArgSpec) -> dict:
+    """Map the arguments from the argspec to their default values."""
+    if not argspec.defaults:
+        return {}
+
+    args_with_default = argspec.args[-len(argspec.defaults):]
+    return {key: value for key, value in zip(
+        args_with_default, argspec.defaults)}
+
+
+def get_arg_spec(function, follow_wrapped=False) -> inspect.FullArgSpec:
+    """
+    Get the arg spec for a function.
+
+    :param function: A function.
+    :param follow_wrapped: Follow `__wrapped__`, defaults to False.
+
+    :return: A :class:`inspect.FullArgSpec`
+    """
+    if follow_wrapped:
+        function = inspect.unwrap(function)
+    return inspect.getfullargspec(function)

--- a/fixtures/_utils.py
+++ b/fixtures/_utils.py
@@ -23,3 +23,24 @@ def get_arg_spec(function, follow_wrapped=False) -> inspect.FullArgSpec:
     if follow_wrapped:
         function = inspect.unwrap(function)
     return inspect.getfullargspec(function)
+
+
+def get_source_location(func: callable):
+    """
+    Get the source location of a function.
+
+    :param func: A function.
+    :return: A tuple of (List[str], str) giving the source lines of the function
+             and it's location as a string "/path/to/file:{linenumber}".
+    """
+    try:
+        source, lineno = inspect.getsourcelines(func)
+        source_file = inspect.getsourcefile(func)
+    except (TypeError, OSError):  # func may be a Callable class
+        if not hasattr(func, "__call__"):
+            raise
+
+        source, lineno = inspect.getsourcelines(func.__call__)
+        source_file = inspect.getsourcefile(func.__call__)
+
+    return source, f"{source_file}:{lineno}"

--- a/fixtures/errors.py
+++ b/fixtures/errors.py
@@ -1,0 +1,55 @@
+"""Exceptions relating to workflow fixtures."""
+from inspect import getsourcefile, getsourcelines
+import inspect
+from typing import Callable
+
+
+class FixtureMultipleYield(ValueError):
+    """Raised when a generator workflow fixture yields more than once."""
+
+
+class FixtureNotFound(KeyError):
+    def __init__(self, name, scope):
+        super().__init__(f"{name} is not a fixture.",
+                         f"Available: {', '.join(scope.available.keys())}")
+
+
+class FixtureBindingError(Exception):
+    """Raised when a required fixture is not available."""
+
+    def _get_source_location(self, func: Callable):
+        try:
+            try:
+                source, lineno = getsourcelines(func)
+                source_file = getsourcefile(func)
+            except (TypeError, OSError):  # func may be a Callable class
+                if hasattr(func, "__call__"):
+                    source, lineno = getsourcelines(func.__call__)
+                    source_file = getsourcefile(func.__call__)
+                else:
+                    raise
+
+            return source, f"{source_file}:{lineno}"
+        except TypeError:
+            return None, None
+
+    def __init__(self, func: Callable, key: str,
+                 reason="Exception occurred while binding fixtures."):
+        """
+        :param func: The function requiring the unavailable fixture
+        :param key: The name of the fixture which could not be instantiated
+        :param reason: The reason for the error
+        """
+        self.func = func
+        self.key = key
+        self.reason = reason
+
+        _, func_location = self._get_source_location(func)
+        message = (f"Failed to bind fixture '{key}'\r\n"
+                   f"Reason: {reason}\r\n"
+                   f"Function: {func} \r\n"
+                   f"Source Location: {func_location}\r\n")
+        super().__init__(message)
+
+    def __str__(self):
+        return self.args[0]

--- a/fixtures/errors.py
+++ b/fixtures/errors.py
@@ -1,7 +1,7 @@
 """Exceptions relating to workflow fixtures."""
-from inspect import getsourcefile, getsourcelines
-import inspect
 from typing import Callable
+
+from ._utils import get_source_location
 
 
 class FixtureMultipleYield(ValueError):
@@ -17,22 +17,6 @@ class FixtureNotFound(KeyError):
 class FixtureBindingError(Exception):
     """Raised when a required fixture is not available."""
 
-    def _get_source_location(self, func: Callable):
-        try:
-            try:
-                source, lineno = getsourcelines(func)
-                source_file = getsourcefile(func)
-            except (TypeError, OSError):  # func may be a Callable class
-                if hasattr(func, "__call__"):
-                    source, lineno = getsourcelines(func.__call__)
-                    source_file = getsourcefile(func.__call__)
-                else:
-                    raise
-
-            return source, f"{source_file}:{lineno}"
-        except TypeError:
-            return None, None
-
     def __init__(self, func: Callable, key: str,
                  reason="Exception occurred while binding fixtures."):
         """
@@ -44,7 +28,8 @@ class FixtureBindingError(Exception):
         self.key = key
         self.reason = reason
 
-        _, func_location = self._get_source_location(func)
+        _, func_location = get_source_location(func)
+
         message = (f"Failed to bind fixture '{key}'\r\n"
                    f"Reason: {reason}\r\n"
                    f"Function: {func} \r\n"

--- a/fixtures/tests/test_fixture_context_behavior.py
+++ b/fixtures/tests/test_fixture_context_behavior.py
@@ -1,10 +1,12 @@
+from contextvars import copy_context
 import pytest
 import asyncio
 from fixtures import fixture_context, get_fixtures, runs_in_new_fixture_context
 
 @pytest.fixture
 def fixtures():
-    with fixture_context():
+    # copy_context=False ensures an empty fixtures dictionary for these tests.
+    with fixture_context(copy_context=False):
         yield get_fixtures()
 
 def test_fixture_context_behavior(fixtures):

--- a/fixtures/tests/test_fixture_context_behavior.py
+++ b/fixtures/tests/test_fixture_context_behavior.py
@@ -1,13 +1,15 @@
-from contextvars import copy_context
-import pytest
 import asyncio
+
+import pytest
 from fixtures import fixture_context, get_fixtures, runs_in_new_fixture_context
+
 
 @pytest.fixture
 def fixtures():
     # copy_context=False ensures an empty fixtures dictionary for these tests.
     with fixture_context(copy_context=False):
         yield get_fixtures()
+
 
 def test_fixture_context_behavior(fixtures):
     fixtures["identity"] = lambda x: x
@@ -51,7 +53,6 @@ async def test_fixture_context_asyncio_behavior(fixtures):
 
     fixtures["identity"] = lambda x: x
 
-
     async def same_context():
         context_fixtures = get_fixtures()
         assert "identity" in fixtures
@@ -59,7 +60,6 @@ async def test_fixture_context_asyncio_behavior(fixtures):
 
         return context_fixtures, fixtures
 
-    
     context_fixtures, fixtures = await same_context()
     assert context_fixtures is fixtures
 
@@ -110,7 +110,7 @@ async def test_fixture_context_no_copy_behavior(fixtures):
 async def test_context_decorator(fixtures):
 
     def baz():
-        ...
+        return "baz"
 
     @runs_in_new_fixture_context(baz)
     async def new_context():
@@ -135,9 +135,3 @@ async def test_context_decorator(fixtures):
 
     assert "cat" in fixtures
     assert "baz" not in fixtures
-
-
-
-
-
-

--- a/fixtures/tests/test_fixture_decoration.py
+++ b/fixtures/tests/test_fixture_decoration.py
@@ -1,0 +1,55 @@
+from fixtures import fixture, get_fixtures, fixture_context, runs_in_new_fixture_context, Fixture
+
+@fixture
+def module_level_fixture():
+    ...
+
+@runs_in_new_fixture_context()
+async def test_fixture_definition_semantics():
+    @fixture
+    def a():
+        ...
+
+    fixtures = get_fixtures()
+
+    # Fixtures defined at module level should always be available.
+    assert module_level_fixture.__name__ in fixtures
+
+
+    assert "a" in fixtures
+    assert fixtures["a"] is a
+
+    with fixture_context() as context_fixtures:
+        assert module_level_fixture.__name__ in fixtures
+
+        @fixture
+        def b():
+            ...
+
+        # The 'b' fixture was created in this context, so it should be seen here.
+        assert "b" in context_fixtures
+        assert context_fixtures["b"] is b
+
+    
+    # 'b' fixture was created in a sub-context, so shouldn't be seen here.
+    assert "b" not in fixtures
+
+    with fixture_context(copy_context=False) as context_fixtures:
+        # Should have an empty context here, even though there are module level fixtures.
+        assert len(context_fixtures) == 0
+
+
+@runs_in_new_fixture_context(copy_context=False)
+async def test_fixture_isinstance_check():
+
+    @fixture
+    def c():
+        ...
+
+    def d():
+        ...
+
+    assert isinstance(c, Fixture)
+    assert not isinstance(d, Fixture)
+
+

--- a/fixtures/tests/test_fixture_decoration.py
+++ b/fixtures/tests/test_fixture_decoration.py
@@ -1,8 +1,11 @@
-from fixtures import fixture, get_fixtures, fixture_context, runs_in_new_fixture_context, Fixture
+from fixtures import (Fixture, fixture, fixture_context, get_fixtures,
+                      runs_in_new_fixture_context)
+
 
 @fixture
 def module_level_fixture():
     ...
+
 
 @runs_in_new_fixture_context()
 async def test_fixture_definition_semantics():
@@ -14,7 +17,6 @@ async def test_fixture_definition_semantics():
 
     # Fixtures defined at module level should always be available.
     assert module_level_fixture.__name__ in fixtures
-
 
     assert "a" in fixtures
     assert fixtures["a"] is a
@@ -30,7 +32,6 @@ async def test_fixture_definition_semantics():
         assert "b" in context_fixtures
         assert context_fixtures["b"] is b
 
-    
     # 'b' fixture was created in a sub-context, so shouldn't be seen here.
     assert "b" not in fixtures
 
@@ -51,5 +52,3 @@ async def test_fixture_isinstance_check():
 
     assert isinstance(c, Fixture)
     assert not isinstance(d, Fixture)
-
-

--- a/fixtures/tests/test_fixture_scope.py
+++ b/fixtures/tests/test_fixture_scope.py
@@ -1,6 +1,8 @@
 import asyncio
+
 import pytest
 from fixtures import FixtureScope, fixture, runs_in_new_fixture_context
+
 
 @runs_in_new_fixture_context(copy_context=False)
 async def test_instantiation_of_fixture_types():
@@ -27,7 +29,6 @@ async def test_instantiation_of_fixture_types():
             yield
         finally:
             gen_finished.set_result(True)
-
 
     @fixture
     async def async_gen_fixture():
@@ -113,7 +114,6 @@ async def test_non_recursive_bind_posargs():
     async with FixtureScope() as scope:
         bound = await scope.bind(with_args)
 
-
         # Function should have been wrapped.
         assert bound is not with_args
         assert bound() == "abcd"
@@ -143,7 +143,6 @@ async def test_recursive_bind_posargs():
     def ab(a):
         return a + "b"
 
-
     @fixture
     def c():
         return "c"
@@ -156,10 +155,8 @@ async def test_recursive_bind_posargs():
     def letters(abc, a, ab, c):
         return abc + a + ab + c
 
-
     def check_letters(letters, ab, a, c, b):
         return letters == ab + c + a + a + b + c
-
 
     async with FixtureScope() as scope:
         bound = await scope.bind(check_letters, b="b")

--- a/fixtures/tests/test_fixture_scope.py
+++ b/fixtures/tests/test_fixture_scope.py
@@ -1,0 +1,76 @@
+import asyncio
+import pytest
+from fixtures import FixtureScope, fixture
+
+async def test_instantiation_of_fixture_types():
+    # Create futures to check which functions have been called.
+    sync_called = asyncio.Future()
+    async_called = asyncio.Future()
+    gen_called = asyncio.Future()
+    gen_finished = asyncio.Future()
+    async_gen_called = asyncio.Future()
+    async_gen_finished = asyncio.Future()
+
+    @fixture
+    def sync_fixture():
+        sync_called.set_result(True)
+
+    @fixture
+    async def async_fixture():
+        async_called.set_result(True)
+
+    @fixture
+    def generator_fixture():
+        gen_called.set_result(True)
+        try:
+            yield
+        finally:
+            gen_finished.set_result(True)
+
+
+    @fixture
+    async def async_gen_fixture():
+        async_gen_called.set_result(True)
+        try:
+            yield
+        finally:
+            async_gen_finished.set_result(True)
+
+    # Instantiate each fixture type and assert they have been called.
+    async with FixtureScope() as scope:
+        await scope._instantiate(sync_fixture)
+        assert sync_called.result() is True
+
+        await scope._instantiate(async_fixture)
+        assert async_called.result() is True
+
+        await scope._instantiate(generator_fixture)
+        assert gen_called.result() is True
+
+        await scope._instantiate(async_gen_fixture)
+        assert async_gen_called.result() is True
+
+    # Generator fixtures should have been finished out on `__aexit__`
+    assert gen_finished.result() is True
+    assert async_gen_finished.result() is True
+
+    # Reset futures for failure case
+    gen_called = asyncio.Future()
+    gen_finished = asyncio.Future()
+    async_gen_called = asyncio.Future()
+    async_gen_finished = asyncio.Future()
+
+    with pytest.raises(RuntimeError):
+        async with FixtureScope() as scope:
+            await scope._instantiate(generator_fixture)
+            assert gen_called.result() is True
+
+            await scope._instantiate(async_gen_fixture)
+            assert async_gen_called.result() is True
+
+            raise RuntimeError()
+
+    # Generator fixtures should still get closed out when there is a failure.
+
+    assert gen_finished.result() is True
+    assert async_gen_finished.result() is True

--- a/fixtures/tests/test_fixtures.py
+++ b/fixtures/tests/test_fixtures.py
@@ -1,0 +1,108 @@
+import pytest
+import asyncio
+from fixtures import fixture_context, get_fixtures
+
+@pytest.fixture
+def fixtures():
+    with fixture_context():
+        yield get_fixtures()
+
+def test_fixture_context_behavior(fixtures):
+    fixtures["identity"] = lambda x: x
+
+    with fixture_context() as context_fixtures:
+        assert "identity" in context_fixtures
+
+        context_fixtures["foo"] = lambda: "bar"
+
+        assert "foo" in context_fixtures
+
+        # should be working with a copy of the fixture dict
+        assert context_fixtures is not fixtures
+
+    assert not "foo" in fixtures
+
+    current_fixtures = get_fixtures()
+
+    # should be back to working with the original dictionary
+    assert current_fixtures is fixtures
+
+    def identity(x):
+        return x
+
+    with fixture_context(identity):
+        context_fixtures = get_fixtures()
+        assert "identity" in context_fixtures
+
+        # Make sure "identity" has been overwritten
+        assert context_fixtures["identity"] is identity
+
+    # Should still be using the old "identity" fixture here
+    assert fixtures["identity"] is not identity
+
+
+async def test_fixture_context_asyncio_behavior(fixtures):
+    fixtures = get_fixtures()
+
+    # Values from the previous test should not be carried forward
+    assert "identity" not in fixtures
+
+    fixtures["identity"] = lambda x: x
+
+
+    async def same_context():
+        context_fixtures = get_fixtures()
+        assert "identity" in fixtures
+        assert context_fixtures is fixtures
+
+        return context_fixtures, fixtures
+
+    
+    context_fixtures, fixtures = await same_context()
+    assert context_fixtures is fixtures
+
+    task = asyncio.create_task(same_context())
+    context_fixtures, fixtures = await task
+    assert context_fixtures is fixtures
+
+    async def different_context():
+        with fixture_context():
+            context_fixtures = get_fixtures()
+            assert "identity" in context_fixtures
+            assert context_fixtures is not fixtures
+
+            context_fixtures["foo"] = lambda: "foo"
+
+            assert "foo" in context_fixtures
+            assert "foo" not in fixtures
+
+            return context_fixtures
+
+    context_fixtures = await different_context()
+
+    assert "foo" not in fixtures
+    assert "foo" in context_fixtures
+
+    task = asyncio.create_task(different_context())
+    context_fixtures = await task
+
+    assert "foo" not in fixtures
+    assert "foo" in context_fixtures
+
+
+async def test_fixture_context_no_copy_behavior(fixtures):
+    assert len(fixtures) == 0
+
+    fixtures["foo"] = lambda: "foo"
+
+    with fixture_context(lambda: None, copy_context=False) as context_fixtures:
+        assert "foo" not in context_fixtures
+        assert "<lambda>" in context_fixtures
+
+        context_fixtures["bar"] = lambda: "bar"
+
+    assert "bar" not in fixtures
+    assert "<lambda>" not in fixtures
+
+
+


### PR DESCRIPTION
Moves the fixtures implementation to a separate package outside of `virtool_workflow`. 

This PR also makes several improvements to the implementation of fixtures such as:

-  Runtime type checking differentiating fixtures from regular functions
    - Supports `isinstance(f, Fixture)` via Protocol and `@runtime_checkable` 
- Use of `contextlib` to implement generator and async generator fixtures.
- Improved fixture binding
    - Positional and keyword arguments can be supplied to bound functions as desired, they will override the bound fixture values.
    - Default values of parameters (on the fixture function) are now respected and will be used when a fixture cannot be instantiated.
- Use of ContextVars to store fixtures.
    - Isolated fixture contexts for separate tests and workflows
    - Fine control over what fixtures are available within a given peice of code, without instance based `FixtureGroup`. 
    - Ability to hide intermediate / framework only fixtures from workflows
    - Reduces clutter in `FixtureNotFound` and `FixtureBindingError` exception messages
