### PR TITLE
Use yml data for integration tests

### DIFF
--- a/integration_tests/analysis/test_case.yml
+++ b/integration_tests/analysis/test_case.yml
@@ -1,0 +1,9 @@
+job_id: analysis_integration_test_job
+workflow: analysis_integration_test
+
+sample:
+  paired: True
+  finalize: True
+
+analysis:
+  ready: False

--- a/integration_tests/hmms/test_case.yml
+++ b/integration_tests/hmms/test_case.yml
@@ -1,0 +1,12 @@
+job_id: hmms_integration_test_job
+workflow: hmms_integration_test
+
+sample:
+  paired: True
+  finalize: True
+
+analysis:
+  ready: False
+
+include:
+  - hmms

--- a/integration_tests/indexes/test_case.yml
+++ b/integration_tests/indexes/test_case.yml
@@ -1,0 +1,11 @@
+job_id: index_integration_test_job
+workflow: index_integration_test
+
+index:
+  finalize: False
+
+analysis:
+  ready: False
+
+include:
+  - otus

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -3,7 +3,7 @@
 set -e
 
 (cd .. && docker build -t virtool/workflow .)
-(cd indexes && workflow test --is-analysis-workflow index_integration_test_job)
-(cd analysis && workflow test --is-analysis-workflow analysis_integration_test_job)
-(cd samples && workflow test --is-analysis-workflow sample_integration_test_job)
-(cd subtractions && workflow test --is-analysis-workflow subtractions_integration_test_job)
+(cd indexes && workflow test --is-analysis-workflow)
+(cd analysis && workflow test --is-analysis-workflow)
+(cd samples && workflow test --is-analysis-workflow)
+(cd subtractions && workflow test --is-analysis-workflow)

--- a/integration_tests/samples/test_case.yml
+++ b/integration_tests/samples/test_case.yml
@@ -1,0 +1,10 @@
+
+job_id: sample_integration_test_job
+workflow: sample_integration_test
+
+sample:
+  finalize: True
+  paired: True
+
+analysis:
+  ready: False

--- a/integration_tests/subtractions/test_case.yml
+++ b/integration_tests/subtractions/test_case.yml
@@ -1,0 +1,10 @@
+job_id: subtractions_integration_test_job
+workflow: subtractions_integration_test
+
+subtractions:
+  - finalize: True
+  - finalize: True
+
+
+analysis:
+  ready: False

--- a/integration_tests/subtractions/workflow.py
+++ b/integration_tests/subtractions/workflow.py
@@ -10,13 +10,9 @@ from virtool_workflow.data_model.subtractions import (NucleotideComposition,
 def test_correct_subtractions(
         subtractions: List[Subtraction],
         work_path: Path,
-        logger
 ):
 
     sub1, sub2 = subtractions
-
-    assert sub1.id == "No3NlHGn"
-    assert sub2.id == "F6698QcC"
 
     assert sub1.gc == NucleotideComposition(
         a=0.25, t=0.25, g=0.25, c=0.25, n=0.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -498,7 +498,7 @@ python-versions = "*"
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
@@ -688,7 +688,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "36d9f21535f038bc0a7647b7da44e97b0f8711e7242347a227e9ee2f91633e8a"
+content-hash = "a81ed0f1bd00c11da2f467561bb5db7ab0d57b1a6c028add83920a8b509679b0"
 
 [metadata.files]
 aiofiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ click = "^7.1.2"
 aiohttp = "^3.7.3"
 aiofiles = "^0.7.0"
 virtool-core = "^0.3.0"
+PyYAML = "^5.4.1"
 
 [tool.poetry.extras]
 test = ["virtool"]

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -17,6 +17,7 @@ async def _run(**kwargs):
 
 
 @apply_options
+@click.argument("job_id")
 @cli.command()
 def run(job_id, **kwargs):
     """Run a workflow."""

--- a/virtool_workflow/options.py
+++ b/virtool_workflow/options.py
@@ -3,7 +3,6 @@ from typing import List
 import click
 
 options = [
-    click.argument("job_id"),
     click.option(
         "--work-path",
         default="temp",

--- a/virtool_workflow/testing/cli.py
+++ b/virtool_workflow/testing/cli.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import click
+import yaml
 from pathlib import Path
 from shutil import which
 from subprocess import PIPE, Popen
@@ -11,12 +13,24 @@ WORKFLOW_COMPOSE_FILE = Path(__file__).parent/"docker-compose.workflow.yml"
 COMPOSE_FILE = f"{API_COMPOSE_FILE.absolute()}:{WORKFLOW_COMPOSE_FILE.absolute()}"
 
 
+@click.option(
+    "--job-id",
+    help="Job ID to use for the workflow run.",
+    default=None,
+)
 @apply_options
-def test_main(**kwargs):
+def test_main(job_id, **kwargs):
     """Run a workflow in a test environment"""
+
+    if job_id is None:
+        with open("test_case.yml", "r") as test_case_yml:
+            yml = yaml.safe_load(test_case_yml)
+            job_id = yml["job_id"]
 
     if which("docker-compose") is None:
         raise RuntimeError("docker-compose is not installed.")
+
+    run_args = [job_id] + sys.argv[2:]
 
     proc = Popen(
         [
@@ -31,7 +45,7 @@ def test_main(**kwargs):
         stdout=PIPE,
         stderr=PIPE,
         env={
-            "VT_ADD_ARGS": " ".join(sys.argv[2:]),
+            "VT_ADD_ARGS": " ".join(run_args),
             "COMPOSE_FILE": COMPOSE_FILE,
             "WORKFLOW_DIR": os.getcwd(),
             **os.environ,

--- a/virtool_workflow/testing/docker-compose.api.yml
+++ b/virtool_workflow/testing/docker-compose.api.yml
@@ -3,21 +3,23 @@ services:
 
   jobs-api:
     image: virtool/virtool:nightly
-    depends_on: 
+    depends_on:
       - mongo
       - redis
       - postgres
       - pgadmin4
-    command: > 
+    command: >
       --db-connection-string="mongodb://mongo:27017"
       --postgres-connection-string="postgresql+asyncpg://virtool:virtool@postgres/virtool"
       --redis-connection-string="redis://redis:6379"
       jobsAPI
-      --fake
+      --fake-path /virtool/fake
       --host=0.0.0.0
       --port=9990
     ports:
       - "9990:9990"
+    volumes:
+        - ${PWD}/test_case.yml:/virtool/fake/test_case.yml
 
   mongo:
     image: mongo:4.4
@@ -70,4 +72,3 @@ volumes:
   vt_redis_data:
   vt_postgres_data:
   vt_pgadmin4_data:
-


### PR DESCRIPTION
Use YAML files to define test cases, instead of relying on them being pre-defined in `virtool/virtool`. 

This PR relies on, and has been tested against, PR [#2342](https://github.com/virtool/virtool/pull/2342) on `virtool/virtool`. 

## Changes

- Change `JOB_ID` to be an optional argument instead of a requirement for `workflow test` command.
-  Find job_id from `test_case.yml` file if available.
-  Mount `test_case.yml` file into the `virtool/virtool` job API docker container.
-  Add `test_case.yml` files for each integration test.