### PR TITLE
Lilly/vir 878 Replace "task" with "workflow" in job documentation

### DIFF
--- a/tests/api/mocks/mock_job_routes.py
+++ b/tests/api/mocks/mock_job_routes.py
@@ -7,7 +7,7 @@ from aiohttp.web_response import json_response
 mock_routes = web.RouteTableDef()
 
 TEST_JOB = {
-    "task": "create_subtraction",
+    "workflow": "create_subtraction",
     "args": {
         "subtraction_id": "Thale",
         "analysis_id": "test_analysis",

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -41,7 +41,7 @@ async def acquire_job_by_id(
                 mem=document["mem"] if "mem" in document else mem,
                 proc=document["proc"] if "proc" in document else proc,
                 status=document["status"],
-                task=document["workflow"] if "workflow" in document else document["task"],
+                workflow=document["workflow"],
                 key=document["key"],
             )
 

--- a/virtool_workflow/data_model/jobs.py
+++ b/virtool_workflow/data_model/jobs.py
@@ -25,7 +25,7 @@ class Job:
     """The number of processes used."""
     status: List[Status] = field(default_factory=lambda: [])
     """The status log for the job."""
-    task: str = None
+    workflow: str = None
     """The name of the workflow which should be used."""
     key: str = None
     """The auth key for the jobs API."""


### PR DESCRIPTION
Update renaming of "task" to "workflow" in job documentation to reflect change in `virtool/virtool`
