### PR TITLE
Better Deployment Scripting & Redis dashboard

### DIFF
--- a/k3s/README.md
+++ b/k3s/README.md
@@ -153,3 +153,12 @@ Now we can make a request to the jobs API.
     "message": "No authorization header."
 }
 ```
+
+
+## Teardown
+
+To quickly tear down all kubernetes objects, use `teardown.sh`.
+
+```shell script
+sudo ./teardown.sh
+```

--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -23,14 +23,14 @@ declare -a manifests=(
 )
 
 
-for manifest in ${manifests[@]};
+for manifest in "${manifests[@]};"
 do 
-    kubectl apply -f $manifest
+    kubectl apply -f "$manifest"
 done
 
 function get_port {
     kubectl get services | 
-        grep -E $1 | 
+        grep -E "$1" | 
         tr -s ' ' | 
         cut -d' ' -f5 | 
         cut -d':' -f2 | 

--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -1,25 +1,40 @@
 #!/bin/bash
 # Deploy The Virtool Server And Jobs API in Kubernetes.
 
-# Redis
-kubectl apply -f ./redis/deployment.yml
-kubectl apply -f ./redis/service.yml
 
-# Postgres
-kubectl apply -f ./postgres/config.yml
-kubectl apply -f ./postgres/volume.yml
-kubectl apply -f ./postgres/deployment.yml
-kubectl apply -f ./postgres/service.yml
+declare -a manifests=(
+    "./redis/deployment.yml"
+    "./redis/service.yml"
+    "./mongo/volume.yml"
+    "./mongo/deployment.yml"
+    "./mongo/service.yml"
+    "./postgres/volume.yml"
+    "./postgres/config.yml"
+    "./postgres/deployment.yml"
+    "./postgres/service.yml"
+    "./server/volume.yml"
+    "./server/deployment.yml"
+    "./server/service.yml"
+    "./jobsAPI/deployment.yml"
+    "./jobsAPI/service.yml"
+    "./create_sample/deployment.yml"
+)
 
-# Mongo
-kubectl apply -f ./mongo/volume.yml
-kubectl apply -f ./mongo/deployment.yml
-kubectl apply -f ./mongo/service.yml
 
-# Jobs API
-kubectl apply -f ./jobsAPI/deployment.yml
-kubectl apply -f ./jobsAPI/service.yml
+for manifest in ${manifests[@]};
+do 
+    kubectl apply -f $manifest
+done
 
-# Virtool Server
-kubectl apply -f ./server/deployment.yml
-kubectl apply -f ./server/service.yml
+function get_port {
+    kubectl get services | 
+        grep -E $1 | 
+        tr -s ' ' | 
+        cut -d' ' -f5 | 
+        cut -d':' -f2 | 
+        cut -d'/' -f1
+}
+
+echo "Virtool Server: http://localhost:$(get_port server)"
+echo "Jobs API: http://localhost:$(get_port job)/api"
+

--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -5,6 +5,8 @@
 declare -a manifests=(
     "./redis/deployment.yml"
     "./redis/service.yml"
+    "./redis/dashboard.yml"
+    "./redis/dashboard-service.yml"
     "./mongo/volume.yml"
     "./mongo/deployment.yml"
     "./mongo/service.yml"
@@ -35,6 +37,9 @@ function get_port {
         cut -d'/' -f1
 }
 
+echo -e "\nServices:\n"
 echo "Virtool Server: http://localhost:$(get_port server)"
 echo "Jobs API: http://localhost:$(get_port job)/api"
+echo "Redis Insight: http://localhost:$(get_port redisinsight)"
+echo "Redis Info: $(kubectl get services | grep "redis " | tr -s ' ')"
 

--- a/k3s/redis/dashboard-service.yml
+++ b/k3s/redis/dashboard-service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redisinsight
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8001
+  selector:
+    app: redisinsight

--- a/k3s/redis/dashboard.yml
+++ b/k3s/redis/dashboard.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redisinsight
+  labels:
+    app: redisinsight
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redisinsight
+  template:
+    metadata:
+      labels:
+        app: redisinsight
+    spec:
+      containers:
+
+      - name:  redisinsight
+        image: redislabs/redisinsight:latest
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: db 
+          mountPath: /db
+        ports:
+        - containerPort: 8001
+          protocol: TCP
+      volumes:
+      - name: db
+        emptyDir: {}

--- a/k3s/refesh.sh
+++ b/k3s/refesh.sh
@@ -2,5 +2,5 @@
 
 # Reload a deployment (so that new docker container will be used)
 
-kubectl scale deployments/$1 --replicas=0
-kubectl scale deployments/$1 --replicas=1
+kubectl scale "deployments/$1" --replicas=0
+kubectl scale "deployments/$1" --replicas=1

--- a/k3s/refesh.sh
+++ b/k3s/refesh.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Reload a deployment (so that new docker container will be used)
+
+kubectl scale deployments/$1 --replicas=0
+kubectl scale deployments/$1 --replicas=1

--- a/k3s/teardown.sh
+++ b/k3s/teardown.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Completely tear down the k3s deployment
+
+for f in $(find . -type f -name *.yml);
+do 
+    kubectl delete -f $f
+done
+

--- a/k3s/teardown.sh
+++ b/k3s/teardown.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Completely tear down the k3s deployment
 
-for f in $(find . -type f -name *.yml);
+for f in $(find . -type f -name ./*.yml);
 do 
     kubectl delete -f "$f"
 done

--- a/k3s/teardown.sh
+++ b/k3s/teardown.sh
@@ -3,6 +3,6 @@
 
 for f in $(find . -type f -name *.yml);
 do 
-    kubectl delete -f $f
+    kubectl delete -f "$f"
 done
 


### PR DESCRIPTION
- Add `teardown.sh` script to delete all kubernetes resources
- Improve `deploy.sh`
    - Iterate over list instead of repeating `kubectl` commands
    - Print  URLs to virtool server and other services
- Add Redis Insight deployment for redis monitoring
     - The redis deployment is added to by entering the cluster IP and port into the redis insight GUI