### PR TITLE
Changes to Support Running `create_sample` Workflow in k3s

### DIFF
--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -22,7 +22,6 @@ declare -a manifests=(
     "./create_sample/deployment.yml"
 )
 
-
 for manifest in "${manifests[@]};"
 do 
     kubectl apply -f "$manifest"
@@ -42,4 +41,3 @@ echo "Virtool Server: http://localhost:$(get_port server)"
 echo "Jobs API: http://localhost:$(get_port job)/api"
 echo "Redis Insight: http://localhost:$(get_port redisinsight)"
 echo "Redis Info: $(kubectl get services | grep "redis " | tr -s ' ')"
-

--- a/k3s/refesh.sh
+++ b/k3s/refesh.sh
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 #!/bin/bash
 
 # Reload a deployment (so that new docker container will be used)

--- a/k3s/refesh.sh
+++ b/k3s/refesh.sh
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 #!/bin/bash
 
 # Reload a deployment (so that new docker container will be used)

--- a/k3s/teardown.sh
+++ b/k3s/teardown.sh
@@ -5,4 +5,3 @@ for f in $(find . -type f -name ./*.yml);
 do 
     kubectl delete -f "$f"
 done
-

--- a/tests/api/mocks/mock_sample_routes.py
+++ b/tests/api/mocks/mock_sample_routes.py
@@ -73,8 +73,7 @@ async def delete(request):
 
 
 @mock_routes.put("/api/samples/{sample_id}/artifacts")
-@mock_routes.put("/api/samples/{sample_id}/reads")
-async def upload_read_files(request):
+async def upload_artifact_files(request):
     sample_id = request.match_info["sample_id"]
 
     if sample_id != TEST_SAMPLE_ID:
@@ -84,6 +83,19 @@ async def upload_read_files(request):
     type = request.query.get("type")
 
     file = await read_file_from_request(request, name, type)
+
+    return json_response(file, status=201)
+
+
+@mock_routes.put("/api/samples/{sample_id}/reads/{name}")
+async def upload_read_files(request):
+    sample_id = request.match_info["sample_id"]
+    name = request.match_info["name"]
+
+    if sample_id != TEST_SAMPLE_ID:
+        return not_found()
+
+    file = await read_file_from_request(request, name, "fastq")
 
     return json_response(file, status=201)
 

--- a/virtool_workflow/api/samples.py
+++ b/virtool_workflow/api/samples.py
@@ -64,10 +64,7 @@ class SampleProvider:
 
     async def upload(self, path: Path, format: VirtoolFileFormat = "fastq") -> VirtoolFile:
         if path.name in ("reads_1.fq.gz", "reads_2.fq.gz"):
-            return await upload_file_via_put(self.http, f"{self.url}/reads", path, params={
-                "name": path.name,
-                "type": format
-            })
+            return await upload_file_via_put(self.http, f"{self.url}/reads/{path.name}", path, params={})
 
         return await upload_file_via_put(self.http, f"{self.url}/artifacts", path, params={
             "name": path.name,


### PR DESCRIPTION
- Test that the same instance is used for `intermediate` fixture
- Use correct API url when uploading read files