### PR TITLE
Send Job Updates

### DIFF
--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+
+from pytest import fixture
+
 from virtool_workflow.api import jobs
 from virtool_workflow.data_model import Status
 from virtool_workflow.testing.fixtures import install_as_pytest_fixtures
-from pytest import fixture
 
 
 @fixture
@@ -24,7 +27,10 @@ async def test_job_can_be_acquired(acquire_job):
 
 async def test_push_status(acquire_job, http, jobs_api_url: str):
     job = await acquire_job("test_job")
-    push_status = jobs.push_status(job, http, jobs_api_url)
-    status = await push_status("running", "test_stage", 40, None)
+    mock_workflow = SimpleNamespace(steps=[print])
+    mock_execution = SimpleNamespace(progress=0, current_step=1)
+    push_status = jobs.push_status(
+            job, http, jobs_api_url, mock_workflow, mock_execution)
+    status = await push_status("running")
 
     assert isinstance(status, Status)

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -67,16 +67,13 @@ def acquire_job(http: aiohttp.ClientSession, jobs_api_url: str, mem: int, proc: 
 class PushStatus(Protocol):
     async def __call__(
         state: State,
-        stage: str,
-        progress: int,
         error: str = None
     ):
         """
         Update the job status.
 
         :param state: The current state of the workflow run.
-        :param stage: The name of the current step.
-        :param progress: The current progress percentage (0-100).
+        :param error: An error message if applicable.
         """
         raise NotImplementedError()
 

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Protocol
+from typing import Protocol, Literal
 
 import aiohttp
 
@@ -62,9 +62,22 @@ def acquire_job(http: aiohttp.ClientSession, jobs_api_url: str, mem: int, proc: 
     return _job_provider
 
 
+State = Literal["complete", "cancelled", "error", "running"]
+
+
 class PushStatus(Protocol):
-    async def __call__(state: str, stage: str, progress: int, error: str = None):
-        ...
+    async def __call__(
+        state: State,
+        stage: str,
+        progress: int,
+        error: str = None
+    ):
+        """
+        Update the workflow status.
+
+        :param: state
+        """
+        raise NotImplementedError()
 
 
 @fixture

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -92,7 +92,7 @@ def push_status(
             f"{jobs_api_url}/jobs/{job.id}/status",
             json={
                 "state": state,
-                "stage": workflow.steps[execution.current_step-1].__name__,
+                "stage": workflow.steps[execution.current_step - 1].__name__,
                 "error": error,
                 "progress": int(execution.progress * 100),
             },

--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Awaitable, Callable, Optional
+from typing import Protocol
 
 import aiohttp
 
@@ -62,7 +62,9 @@ def acquire_job(http: aiohttp.ClientSession, jobs_api_url: str, mem: int, proc: 
     return _job_provider
 
 
-PushStatus = Callable[[str, str, int, Optional[str]], Awaitable[Status]]
+class PushStatus(Protocol):
+    async def __call__(state: str, stage: str, progress: int, error: str = None):
+        ...
 
 
 @fixture

--- a/virtool_workflow/data_model/__init__.py
+++ b/virtool_workflow/data_model/__init__.py
@@ -1,7 +1,7 @@
 from .analysis import Analysis
 from .hmms import HMM
 from .indexes import Index
-from .jobs import Job, Status
+from .jobs import Job, Status, State
 from .references import Reference
 from .samples import Sample
 from .subtractions import Subtraction, NucleotideComposition
@@ -11,9 +11,10 @@ __all__ = [
     "HMM",
     "Index",
     "Job",
-    "Status",
     "NucleotideComposition",
     "Reference",
     "Sample",
+    "State",
+    "Status",
     "Subtraction",
 ]

--- a/virtool_workflow/data_model/jobs.py
+++ b/virtool_workflow/data_model/jobs.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Literal
+
+
+State = Literal["complete", "cancelled", "error", "running"]
 
 
 @dataclass(frozen=True)
 class Status:
     """The status of a Virtool Job."""
-    error: str
+    error: State
     progress: float
     stage: str
     state: str

--- a/virtool_workflow/runtime/runtime.py
+++ b/virtool_workflow/runtime/runtime.py
@@ -39,7 +39,7 @@ def load_scripts(init_file: Path, fixtures_file: Path):
 def setup_hooks():
     """Add hooks for a workflow run."""
     hooks.on_update(status.send_status, once=True)
-    hooks.on_failure(status.send_error, once=True)
+    hooks.on_failure(status.send_failed, once=True)
     hooks.on_cancelled(status.send_cancelled, once=True)
     hooks.on_success(status.send_complete, once=True)
 

--- a/virtool_workflow/runtime/status.py
+++ b/virtool_workflow/runtime/status.py
@@ -2,33 +2,19 @@
 
 
 async def send_status(push_status, workflow, execution):
-    await push_status(
-        state="running",
-        stage=workflow.steps[execution.current_step],
-        progress=execution.progress,
-    )
+    await push_status(state="running",)
 
 
 async def send_complete(push_status, workflow, execution):
-    await push_status(
-        state="complete",
-        stage=workflow.steps[execution.current_step],
-        progress=100,
-    )
+    await push_status(state="complete")
 
 
 async def send_failed(push_status, error, workflow, execution):
     await push_status(
         state="error",
-        stage=workflow.steps[execution.current_step],
-        progress=100,
         error=str(error)
     )
 
 
 async def send_cancelled(push_status, workflow, execution):
-    await push_status(
-        state="cancelled",
-        stage=workflow.steps[execution.current_step],
-        progress=execution.progress,
-    )
+    await push_status(state="cancelled")

--- a/virtool_workflow/runtime/status.py
+++ b/virtool_workflow/runtime/status.py
@@ -1,0 +1,34 @@
+"""Utility functions for sending status updates."""
+
+
+async def send_status(push_status, workflow, execution):
+    await push_status(
+        state="running",
+        stage=workflow.steps[execution.current_step],
+        progress=execution.progress,
+    )
+
+
+async def send_complete(push_status, workflow, execution):
+    await push_status(
+        state="complete",
+        stage=workflow.steps[execution.current_step],
+        progress=100,
+    )
+
+
+async def send_failed(push_status, error, workflow, execution):
+    await push_status(
+        state="error",
+        stage=workflow.steps[execution.current_step],
+        progress=100,
+        error=str(error)
+    )
+
+
+async def send_cancelled(push_status, workflow, execution):
+    await push_status(
+        state="cancelled",
+        stage=workflow.steps[execution.current_step],
+        progress=execution.progress,
+    )


### PR DESCRIPTION
Use the `push_status` fixture to send updates when the `on_update`, `on_success`, `on_failure`, and `on_cancelled` hooks are triggered.

- Refactor `push_status` fixture
      - Use callback protocol
      - Get `stage` and `progress` from `execution` fixture

- Add handlers for `on_update`, `on_success`, `on_failure`, and `on_cancelled` hooks.
     - Send the appropriate status via jobs API status endpoint.