### PR TITLE
Skip updating dockerhub README.

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,11 +26,3 @@ jobs:
           tags: virtool/workflow:nightly
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Update README on Docker Hub
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: virtool/workflow
-          readme-filepath: ./docker/README.md


### PR DESCRIPTION
The action for updating the README on dockerhub is failing. It has been removed, since README updates can be pushed manually.