### PR TITLE
fix: prevent work path carryover between jobs

### DIFF
--- a/virtool_workflow/builtin_fixtures.py
+++ b/virtool_workflow/builtin_fixtures.py
@@ -17,7 +17,8 @@ def results() -> dict:
 def work_path(config: dict) -> Path:
     """A temporary working directory."""
     path = Path(config["work_path"]).absolute()
-    path.mkdir(parents=True, exist_ok=True)
+    rmtree(path, ignore_errors=True)    
+    path.mkdir(parents=True)
     yield path
     rmtree(path)
 


### PR DESCRIPTION
Prevent work path carryover between jobs in the same runner instance.

Make sure work path does not exist before creating instead of relying on the previous
run having cleaned up after itself.

Greater issue still needs to be resolved:
https://linear.app/virtool/issue/VIR-1073/fixtures-my-not-be-cleaned-up-when-error-happens-during-collection