### PR TITLE
Accept subtraction_id in job args

### DIFF
--- a/virtool_workflow/runtime/providers.py
+++ b/virtool_workflow/runtime/providers.py
@@ -46,7 +46,12 @@ def sample_provider(job, http, jobs_api_url) -> SampleProvider:
 def subtraction_providers(
     job, http, jobs_api_url, work_path
 ) -> List[SubtractionProvider]:
-    ids = job.args["subtractions"]
+    try:
+        ids = job.args["subtractions"]
+    except KeyError:
+        # Supports the create_subtraction workflow.
+        ids = [job.args["subtraction_id"]]
+
     if isinstance(ids, str) or isinstance(ids, bytes):
         ids = [ids]
 


### PR DESCRIPTION
This form is used by the `create_subtraction` workflow and support was inadvertently removed in d956ce3.

Accept subtraction IDs in job args from keys `subtraction_id` and `subtractions`.