### PR TITLE
Start logging as soon as workflow is executed

### DIFF
--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -1,11 +1,12 @@
 """Command Line Interface to virtool_workflow"""
 import asyncio
+
 import click
 
-from virtool_workflow.runtime import runtime
-from virtool_workflow.testing.cli import test_main
 from virtool_workflow.options import apply_options
+from virtool_workflow.runtime import runtime
 from virtool_workflow.runtime.redis import run_jobs_from_redis
+from virtool_workflow.testing.cli import test_main
 
 
 @click.group()
@@ -22,6 +23,7 @@ async def _run(**kwargs):
 @cli.command()
 def run(job_id, **kwargs):
     """Run a workflow."""
+    runtime.configure_logging()
     asyncio.run(_run(job_id=job_id, **kwargs))
 
 

--- a/virtool_workflow/runtime/runtime.py
+++ b/virtool_workflow/runtime/runtime.py
@@ -12,16 +12,15 @@ from virtool_workflow.runtime import status
 logger = logging.getLogger(__name__)
 
 
-def configure_logging(dev_mode):
+def configure_logging():
     """Set up logging for a workflow run."""
-    log_level = logging.DEBUG if dev_mode else logging.INFO
+    logging.basicConfig(level=logging.DEBUG)
 
-    logging.basicConfig(level=log_level)
     # Install coloredlogs if available.
     with suppress(ModuleNotFoundError):
         import coloredlogs
         logging.debug("Installed coloredlogs")
-        coloredlogs.install(level=log_level)
+        coloredlogs.install(level=logging.DEBUG)
 
 
 def load_scripts(init_file: Path, fixtures_file: Path):
@@ -54,8 +53,7 @@ async def run_workflow(workflow: Workflow, config: dict):
 
 @asynccontextmanager
 async def prepare_workflow(**config):
-    """Prepare for a workflow run."""
-    configure_logging(config["dev_mode"])
+    """Prepare for a workflow run."""    
     load_scripts(Path(config["init_file"]), Path(config["fixtures_file"]))
 
     workflow = discovery.discover_workflow(


### PR DESCRIPTION
Configure logging at CLI entry instead of in workflow preparation.

I believe this is making essential logging not write to the console.