### PR TITLE
fix: remove /api prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,3 @@
-# HMMER and Skewer
-FROM debian:buster as debian
-WORKDIR /build
-RUN apt-get update && apt-get install -y build-essential wget bioperl
-RUN wget http://eddylab.org/software/hmmer/hmmer-3.2.1.tar.gz && \
-    tar -xf hmmer-3.2.1.tar.gz && \
-    cd hmmer-3.2.1 && \
-    ./configure --prefix /build/hmmer && \
-    make && \
-    make install && \
-    wget https://github.com/relipmoc/skewer/archive/0.2.2.tar.gz && \
-    tar -xf 0.2.2.tar.gz && \
-    cd skewer-0.2.2 && \
-    make && \
-    mv skewer /build
-
-# Bowtie2
-FROM alpine:latest as bowtie
-WORKDIR /build
-RUN wget https://github.com/BenLangmead/bowtie2/releases/download/v2.3.2/bowtie2-2.3.2-legacy-linux-x86_64.zip && \
-    unzip bowtie2-2.3.2-legacy-linux-x86_64.zip && \
-    mkdir bowtie2 && \
-    cp bowtie2-2.3.2-legacy/bowtie2* bowtie2
-
-# FastQC
-FROM alpine:latest as fastqc
-WORKDIR /build
-RUN wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.9.zip && \
-    unzip fastqc_v0.11.9.zip
-
-# Pigz
-FROM debian:buster as pigz
-WORKDIR /build
-RUN apt-get update && apt-get install -y make gcc zlib1g-dev wget
-RUN wget https://zlib.net/pigz/pigz-2.6.tar.gz && \
-    tar -xzvf pigz-2.6.tar.gz && \
-    cd pigz-2.6 && \
-    make
-
 # virtool-workflow dependencies
 FROM python:3.8-slim as pip_install
 WORKDIR /install
@@ -45,28 +6,13 @@ COPY pyproject.toml ./pyproject.toml
 COPY poetry.lock ./poetry.lock
 RUN /root/.local/bin/poetry export > requirements.txt
 RUN pip install --user -r requirements.txt
+
+
+FROM virtool/workflow-tools:1.0.0
+COPY --from=pip_install /root/.local /root/.local
+
+WORKDIR /workflow
 COPY . .
 RUN pip install --user .
-
-
-FROM python:3.8-buster as jre
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends default-jre && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
-
-FROM jre as main
-COPY --from=pip_install /root/.local /root/.local
-COPY --from=bowtie /build/bowtie2/* /usr/local/bin/
-COPY --from=debian /build/hmmer /opt/hmmer
-COPY --from=debian /build/skewer /usr/local/bin/
-COPY --from=fastqc /build/FastQC /opt/fastqc
-COPY --from=pigz /build/pigz-2.6/pigz /usr/local/bin/pigz
-
-RUN chmod ugo+x /opt/fastqc/fastqc && \
-    ln -fs /opt/fastqc/fastqc /usr/local/bin/fastqc && \
-    for file in `ls /opt/hmmer/bin`; do ln -fs /opt/hmmer/bin/${file} /usr/local/bin/${file};  done
-
-ENV PATH $PATH:/root/.local/bin
 
 ENTRYPOINT ["workflow", "run"]

--- a/k3s/README.md
+++ b/k3s/README.md
@@ -48,7 +48,7 @@ deployment.apps/create-sample-runner created
 Services:
 
 Virtool Server: http://localhost:30908
-Jobs API: http://localhost:32579/api
+Jobs API: http://localhost:32579
 Redis Insight: http://localhost:31808
 Redis Info: redis ClusterIP 10.43.67.186 <none> 6379/TCP 6s
 ```
@@ -111,7 +111,7 @@ Address 1: 10.43.27.20 jobs-api.default.svc.cluster.local
 
 Now we can make a request to the jobs API.
 
-> `kubectl exec curl curl http://jobs-api.default.svc.cluster.local/api`
+> `kubectl exec curl curl http://jobs-api.default.svc.cluster.local`
 
 ```text
 {

--- a/k3s/create_sample/deployment.yml
+++ b/k3s/create_sample/deployment.yml
@@ -27,6 +27,6 @@ spec:
             - name: VT_RUN_FROM_REDIS_IS_ANALYSIS_WORKFLOW
               value: 'true'
             - name: VT_RUN_FROM_REDIS_JOBS_API_URL
-              value: 'http://jobs-api.default.svc.cluster.local:9990/api'
+              value: 'http://jobs-api.default.svc.cluster.local:9990'
             - name: VT_RUN_FROM_REDIS_REDIS_URL
               value: 'redis://redis.default.svc.cluster.local:6379'

--- a/k3s/create_subtraction/deployment.yml
+++ b/k3s/create_subtraction/deployment.yml
@@ -27,6 +27,6 @@ spec:
             - name: VT_RUN_FROM_REDIS_IS_ANALYSIS_WORKFLOW
               value: 'true'
             - name: VT_RUN_FROM_REDIS_JOBS_API_URL
-              value: 'http://jobs-api.default.svc.cluster.local:9990/api'
+              value: 'http://jobs-api.default.svc.cluster.local:9990'
             - name: VT_RUN_FROM_REDIS_REDIS_URL
               value: 'redis://redis.default.svc.cluster.local:6379'

--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -39,6 +39,6 @@ function get_port {
 
 echo -e "\nServices:\n"
 echo "Virtool Server: http://localhost:$(get_port server)"
-echo "Jobs API: http://localhost:$(get_port job)/api"
+echo "Jobs API: http://localhost:$(get_port job)"
 echo "Redis Insight: http://localhost:$(get_port redisinsight)"
 echo "Redis Info: $(kubectl get services | grep "redis " | tr -s ' ')"

--- a/tests/api/fixtures.py
+++ b/tests/api/fixtures.py
@@ -13,7 +13,7 @@ def loop(event_loop):
 
 @pytest.fixture
 async def jobs_api_url():
-    return "/api"
+    return ""
 
 
 @pytest.fixture

--- a/tests/api/mocks/mock_analysis_routes.py
+++ b/tests/api/mocks/mock_analysis_routes.py
@@ -6,7 +6,7 @@ from tests.conftest import TEST_FILES_DIR
 mock_routes = web.RouteTableDef()
 
 
-@mock_routes.get("/api/analyses/{analysis_id}")
+@mock_routes.get("/analyses/{analysis_id}")
 async def get_analysis(request):
     id_ = request.match_info["analysis_id"]
 
@@ -41,7 +41,7 @@ async def get_analysis(request):
     )
 
 
-@mock_routes.put("/api/analyses/{analysis_id}/files")
+@mock_routes.put("/analyses/{analysis_id}/files")
 async def upload_file(request):
     name = request.query.get("name")
     format = request.query.get("format")
@@ -51,7 +51,7 @@ async def upload_file(request):
     )
 
 
-@mock_routes.get("/api/analyses/{analysis_id}/files/{file_id}")
+@mock_routes.get("/analyses/{analysis_id}/files/{file_id}")
 async def download(request):
     file_id = request.match_info["file_id"]
     analysis_id = request.match_info["analysis_id"]
@@ -66,7 +66,7 @@ async def download(request):
     return web.json_response({"message": "Not Found"}, status=404)
 
 
-@mock_routes.delete("/api/analyses/{analysis_id}")
+@mock_routes.delete("/analyses/{analysis_id}")
 async def delete(request):
     analysis_id = request.match_info["analysis_id"]
 
@@ -76,7 +76,7 @@ async def delete(request):
     return web.Response(status=204)
 
 
-@mock_routes.patch("/api/analyses/{analysis_id}")
+@mock_routes.patch("/analyses/{analysis_id}")
 async def upload_result(request):
     analysis_id = request.match_info["analysis_id"]
     if analysis_id != TEST_ANALYSIS_ID:

--- a/tests/api/mocks/mock_cache_routes.py
+++ b/tests/api/mocks/mock_cache_routes.py
@@ -9,21 +9,21 @@ caches = {}
 mock_routes = RouteTableDef()
 
 
-@mock_routes.post("/api/caches/{key}")
+@mock_routes.post("/caches/{key}")
 def create_cache_placeholder(request):
     raise NotImplementedError()
 
 
-@mock_routes.put("/api/caches/{key}/files")
+@mock_routes.put("/caches/{key}/files")
 def upload_cache_file(request):
     raise NotImplementedError()
 
 
-@mock_routes.get("/api/caches/{key}")
+@mock_routes.get("/caches/{key}")
 def get_cache(request):
     raise NotImplementedError()
 
 
-@mock_routes.patch("/api/caches/{key}")
+@mock_routes.patch("/caches/{key}")
 def finalize(request):
     raise NotImplementedError()

--- a/tests/api/mocks/mock_hmm_routes.py
+++ b/tests/api/mocks/mock_hmm_routes.py
@@ -48,7 +48,7 @@ MOCK_HMM = {
 HMM_PROFILES = ANALYSIS_TEST_FILES_DIR / "profiles.hmm"
 
 
-@mock_routes.get("/api/hmms/{hmm_id}")
+@mock_routes.get("/hmms/{hmm_id}")
 async def get(request):
     hmm_id = request.match_info["hmm_id"]
 
@@ -60,12 +60,12 @@ async def get(request):
     return json_response(MOCK_HMM)
 
 
-@mock_routes.get('/api/hmms/files/profiles.hmm')
+@mock_routes.get('/hmms/files/profiles.hmm')
 async def download_hmm_profiles(request):
     return FileResponse(HMM_PROFILES)
 
 
-@mock_routes.get('/api/hmms/files/annotations.json.gz')
+@mock_routes.get('/hmms/files/annotations.json.gz')
 async def download_annotations(request):
     annotations_path = ANALYSIS_TEST_FILES_DIR/"annotations.json"
     compressed_annotations_path = annotations_path.with_suffix(".json.gz")

--- a/tests/api/mocks/mock_index_routes.py
+++ b/tests/api/mocks/mock_index_routes.py
@@ -35,7 +35,7 @@ TEST_INDEX = {
     }
 
 
-@mock_routes.get("/api/indexes/{index_id}")
+@mock_routes.get("/indexes/{index_id}")
 async def get_index(request):
     if request.match_info["index_id"] != TEST_INDEX_ID:
         return web.json_response({"message": "Not Found"}, status=404)
@@ -43,7 +43,7 @@ async def get_index(request):
     return web.json_response(TEST_INDEX, status=200)
 
 
-@mock_routes.get("/api/refs/{ref_id}")
+@mock_routes.get("/refs/{ref_id}")
 async def get_ref(request):
     ref_id = request.match_info["ref_id"]
 
@@ -76,7 +76,7 @@ async def get_ref(request):
     }, status=200)
 
 
-@mock_routes.put("/api/indexes/{index_id}/files/{name}")
+@mock_routes.put("/indexes/{index_id}/files/{name}")
 async def upload_index_file(request):
     name = request.match_info.get("name")
 
@@ -101,7 +101,7 @@ async def upload_index_file(request):
     }, status=201)
 
 
-@mock_routes.get("/api/indexes/{index_id}/files/{filename}")
+@mock_routes.get("/indexes/{index_id}/files/{filename}")
 async def download_index_files(request):
     index_id = request.match_info["index_id"]
     filename = request.match_info["filename"]
@@ -127,7 +127,7 @@ async def download_index_files(request):
     return web.FileResponse(path)
 
 
-@mock_routes.patch("/api/indexes/{index_id}")
+@mock_routes.patch("/indexes/{index_id}")
 async def finalize_index(request):
     TEST_INDEX["ready"] = True
 

--- a/tests/api/mocks/mock_job_routes.py
+++ b/tests/api/mocks/mock_job_routes.py
@@ -53,7 +53,7 @@ TEST_JOB = {
 }
 
 
-@mock_routes.patch("/api/jobs/{job_id}")
+@mock_routes.patch("/jobs/{job_id}")
 async def acquire_job(request):
     json = await request.json()
 
@@ -63,7 +63,7 @@ async def acquire_job(request):
     return web.json_response(TEST_JOB, status=200)
 
 
-@mock_routes.post("/api/jobs/{job_id}/status")
+@mock_routes.post("/jobs/{job_id}/status")
 async def push_status(request):
     job_id = request.match_info["job_id"]
 

--- a/tests/api/mocks/mock_sample_routes.py
+++ b/tests/api/mocks/mock_sample_routes.py
@@ -31,7 +31,7 @@ TEST_CACHE = {
 }
 
 
-@mock_routes.get("/api/samples/{sample_id}")
+@mock_routes.get("/samples/{sample_id}")
 async def get_sample(request):
     sample_id = request.match_info["sample_id"]
 
@@ -41,7 +41,7 @@ async def get_sample(request):
     return json_response(TEST_SAMPLE, status=200)
 
 
-@mock_routes.patch("/api/samples/{sample_id}")
+@mock_routes.patch("/samples/{sample_id}")
 async def finalize(request):
     sample_id = request.match_info["sample_id"]
 
@@ -56,7 +56,7 @@ async def finalize(request):
     return json_response(TEST_SAMPLE)
 
 
-@mock_routes.delete("/api/samples/{sample_id}")
+@mock_routes.delete("/samples/{sample_id}")
 async def delete(request):
     sample_id = request.match_info["sample_id"]
 
@@ -72,7 +72,7 @@ async def delete(request):
     return Response(status=204)
 
 
-@mock_routes.put("/api/samples/{sample_id}/artifacts")
+@mock_routes.put("/samples/{sample_id}/artifacts")
 async def upload_artifact_files(request):
     sample_id = request.match_info["sample_id"]
 
@@ -87,7 +87,7 @@ async def upload_artifact_files(request):
     return json_response(file, status=201)
 
 
-@mock_routes.put("/api/samples/{sample_id}/reads/{name}")
+@mock_routes.put("/samples/{sample_id}/reads/{name}")
 async def upload_read_files(request):
     sample_id = request.match_info["sample_id"]
     name = request.match_info["name"]
@@ -100,7 +100,7 @@ async def upload_read_files(request):
     return json_response(file, status=201)
 
 
-@mock_routes.get("/api/samples/{sample_id}/reads/{filename}")
+@mock_routes.get("/samples/{sample_id}/reads/{filename}")
 async def download_reads_file(request):
     sample_id = request.match_info["sample_id"]
     filename = request.match_info["filename"]
@@ -113,8 +113,8 @@ async def download_reads_file(request):
     return FileResponse(ANALYSIS_TEST_FILES_DIR / file_name)
 
 
-@mock_routes.get("/api/samples/{sample_id}/caches/{key}/artifacts/{filename}")
-@mock_routes.get("/api/samples/{sample_id}/artifacts/{filename}")
+@mock_routes.get("/samples/{sample_id}/caches/{key}/artifacts/{filename}")
+@mock_routes.get("/samples/{sample_id}/artifacts/{filename}")
 async def download_artifact(request):
     sample_id = request.match_info["sample_id"]
     filename = request.match_info["filename"]
@@ -130,7 +130,7 @@ async def download_artifact(request):
     return FileResponse(file)
 
 
-@mock_routes.post("/api/samples/{sample_id}/caches")
+@mock_routes.post("/samples/{sample_id}/caches")
 async def create_mock_cache(request):
     sample_id = request.match_info["sample_id"]
 
@@ -146,7 +146,7 @@ async def create_mock_cache(request):
         return not_found()
 
 
-@mock_routes.put("/api/samples/{sample_id}/caches/{key}/artifacts")
+@mock_routes.put("/samples/{sample_id}/caches/{key}/artifacts")
 async def upload_artifact_to_cache(request):
     sample_id = request.match_info["sample_id"]
     key = request.match_info["key"]
@@ -161,7 +161,7 @@ async def upload_artifact_to_cache(request):
     return json_response(document, status=201)
 
 
-@mock_routes.put("/api/samples/{sample_id}/caches/{key}/reads/{name}")
+@mock_routes.put("/samples/{sample_id}/caches/{key}/reads/{name}")
 async def upload_reads_to_cache(request):
     name = request.match_info["name"]
     sample_id = request.match_info["sample_id"]
@@ -177,7 +177,7 @@ async def upload_reads_to_cache(request):
     return json_response(document, status=201)
 
 
-@mock_routes.patch("/api/samples/{sample_id}/caches/{key}")
+@mock_routes.patch("/samples/{sample_id}/caches/{key}")
 async def finalize_cache(request):
     sample_id = request.match_info["sample_id"]
     key = request.match_info["key"]
@@ -194,7 +194,7 @@ async def finalize_cache(request):
     return json_response(TEST_CACHE)
 
 
-@mock_routes.get("/api/samples/{sample_id}/caches/{key}")
+@mock_routes.get("/samples/{sample_id}/caches/{key}")
 async def get_cache(request):
     sample_id = request.match_info["sample_id"]
     key = request.match_info["key"]
@@ -205,7 +205,7 @@ async def get_cache(request):
     return json_response(TEST_CACHE)
 
 
-@mock_routes.delete("/api/samples/{sample_id}/caches/{key}")
+@mock_routes.delete("/samples/{sample_id}/caches/{key}")
 async def delete_cache(request):
     sample_id = request.match_info["sample_id"]
     key = request.match_info["key"]
@@ -219,7 +219,7 @@ async def delete_cache(request):
     return Response(status=204)
 
 
-@mock_routes.get("/api/samples/{sample_id}/caches/{key}/reads/{name}")
+@mock_routes.get("/samples/{sample_id}/caches/{key}/reads/{name}")
 async def download_cached_reads(request):
     name = request.match_info["name"]
 

--- a/tests/api/mocks/mock_subtraction_routes.py
+++ b/tests/api/mocks/mock_subtraction_routes.py
@@ -34,7 +34,7 @@ TEST_SUBTRACTION = {
 }
 
 
-@mock_routes.get("/api/subtractions/{subtraction_id}")
+@mock_routes.get("/subtractions/{subtraction_id}")
 def get_subtraction(request):
     subtraction_id = request.match_info["subtraction_id"]
 
@@ -46,7 +46,7 @@ def get_subtraction(request):
     return web.json_response(TEST_SUBTRACTION, status=200)
 
 
-@mock_routes.put("/api/subtractions/{subtraction_id}/files/{filename}")
+@mock_routes.put("/subtractions/{subtraction_id}/files/{filename}")
 async def upload_subtraction_file(request):
     name = request.match_info["filename"]
 
@@ -66,7 +66,7 @@ async def upload_subtraction_file(request):
     return web.json_response(await read_file_from_request(request, name, "bt2"), status=201)
 
 
-@mock_routes.patch("/api/subtractions/{subtraction_id}")
+@mock_routes.patch("/subtractions/{subtraction_id}")
 async def finalize_subtraction(request):
     subtraction_id = request.match_info["subtraction_id"]
 
@@ -82,7 +82,7 @@ async def finalize_subtraction(request):
     return web.json_response(TEST_SUBTRACTION)
 
 
-@mock_routes.delete("/api/subtractions/{subtraction_id}")
+@mock_routes.delete("/subtractions/{subtraction_id}")
 async def delete_subtraction(request):
     subtraction_id = request.match_info["subtraction_id"]
 
@@ -95,6 +95,6 @@ async def delete_subtraction(request):
     return web.Response(status=204)
 
 
-@mock_routes.get("/api/subtractions/{subtraction_id}/files/{filename}")
+@mock_routes.get("/subtractions/{subtraction_id}/files/{filename}")
 async def download_subtraction_data(request):
     return web.Response(status=200)

--- a/virtool_workflow/api/analysis.py
+++ b/virtool_workflow/api/analysis.py
@@ -74,7 +74,7 @@ class AnalysisProvider:
 
     :param analysis_id: The ID of the current analysis as found in the job args.
     :param http: A :class:`aiohttp.ClientSession` instance to be used when making requests.
-    :param jobs_api_url: The url to the Jobs API. It should include the `/api` path.
+    :param jobs_api_url: The url to the Jobs API.
 
     """
 

--- a/virtool_workflow/api/indexes.py
+++ b/virtool_workflow/api/indexes.py
@@ -30,7 +30,7 @@ class IndexProvider:
     :param ref_id: The reference ID for the current job.
     :param index_path: The file system path to store index files.
     :param http: An :obj:`aiohttp.ClientSession` to use when making HTTP requests.
-    :param jobs_api_url: The base URL for the jobs API (should include `/api`).
+    :param jobs_api_url: The base URL for the jobs API.
     """
 
     def __init__(self,

--- a/virtool_workflow/api/subtractions.py
+++ b/virtool_workflow/api/subtractions.py
@@ -28,7 +28,7 @@ class SubtractionProvider:
 
     :param subtraction_id: The ID of the subtraction.
     :param http: An class:`aiohttp.ClientSession` to use when making requests.
-    :param jobs_api_url: The url for the jobs API (including /api).
+    :param jobs_api_url: The url for the jobs API.
     :param subtraction_work_path: The working path for subtraction files.
     """
 

--- a/virtool_workflow/options.py
+++ b/virtool_workflow/options.py
@@ -29,7 +29,7 @@ options = [
     click.option(
         "--jobs-api-url",
         help="The URL of the jobs API.",
-        default="https://localhost:9950/api",
+        default="https://localhost:9950",
     ),
     click.option(
         "--is-analysis-workflow",

--- a/virtool_workflow/testing/docker-compose.api.yml
+++ b/virtool_workflow/testing/docker-compose.api.yml
@@ -2,7 +2,7 @@ version: "3.1"
 services:
 
   jobs-api:
-    image: virtool/virtool:5.4.0
+    image: virtool/virtool:6.3.3
     depends_on:
       - mongo
       - redis

--- a/virtool_workflow/testing/docker-compose.workflow.yml
+++ b/virtool_workflow/testing/docker-compose.workflow.yml
@@ -6,7 +6,7 @@ services:
         tty: true
         entrypoint: > 
             workflow run
-            --jobs-api-url=http://jobs-api:9990/api
+            --jobs-api-url=http://jobs-api:9990
             ${VT_ADD_ARGS}
         depends_on:
             - jobs-api


### PR DESCRIPTION
The `virtool/virtool` server image has removed the `/api` prefix.

This PR updates `virtool-workflow` to avoid using `/api/`