### PR TITLE
Add option to run a single job from redis

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ pytest_plugins = [
     "tests.integration._fixtures.db", 
     "tests.integration._fixtures.jobs", 
     "tests.integration._fixtures.workflows",
+    "tests.integration._fixtures.redis",
     "virtool_workflow.testing.fixtures",
 ]
 

--- a/tests/integration/_fixtures/containers.py
+++ b/tests/integration/_fixtures/containers.py
@@ -18,11 +18,11 @@ def pg_url(module_scoped_container_getter):
 
 
 @pytest.fixture(scope="module")
-def redis_url(module_scoped_container_getter):
+def redis_service(module_scoped_container_getter):
     service = module_scoped_container_getter.get("redis")
     network_info = service.network_info[0]
 
-    return f"redis://redis{network_info.hostname}:{network_info.host_port}"
+    return f"redis://{network_info.hostname}:{network_info.host_port}"
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/_fixtures/containers.py
+++ b/tests/integration/_fixtures/containers.py
@@ -16,6 +16,15 @@ def pg_url(module_scoped_container_getter):
 
     return f"postgresql+asyncpg://virtool:virtool@{network_info.hostname}/virtool"
 
+
+@pytest.fixture(scope="module")
+def redis_url(module_scoped_container_getter):
+    service = module_scoped_container_getter.get("redis")
+    network_info = service.network_info[0]
+
+    return f"redis://redis{network_info.hostname}:{network_info.host_port}"
+
+
 @pytest.fixture(scope="module")
 def jobs_api_service(module_scoped_container_getter):
     return module_scoped_container_getter.get("jobs-api")

--- a/tests/integration/_fixtures/redis.py
+++ b/tests/integration/_fixtures/redis.py
@@ -1,0 +1,15 @@
+import pytest
+from virtool_core.redis import connect_to_redis
+
+
+@pytest.fixture
+async def redis(redis_service):
+    _redis = await connect_to_redis(redis_service)
+    try:
+        yield _redis
+    finally:
+        _redis.close()
+        await _redis.wait_closed()
+
+    
+

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,0 +1,26 @@
+from virtool_workflow import Workflow
+from virtool_workflow.runtime.redis import _run_job_from_redis, get_job_id_from_redis
+
+
+async def test_run_once_from_redis(create_job, redis, redis_service, base_config):
+    job = await create_job({})
+
+    list_name = f"{job['workflow']}_jobs"
+    await redis.lpush(list_name, job["_id"])
+
+    redis.close()
+    await redis.wait_closed()
+
+
+    workflow = Workflow()
+
+    workflow_did_run = False
+
+    @workflow.step
+    def test_workflow(job, logger):
+        nonlocal workflow_did_run
+        workflow_did_run = True
+
+    await _run_job_from_redis(list_name, redis_service, workflow, **base_config)
+
+    assert workflow_did_run

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,5 +1,5 @@
 from virtool_workflow import Workflow
-from virtool_workflow.runtime.redis import _run_job_from_redis, get_job_id_from_redis
+from virtool_workflow.runtime.redis import _run_job_from_redis
 
 
 async def test_run_once_from_redis(create_job, redis, redis_service, base_config):

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -25,7 +25,8 @@ def run(job_id, **kwargs):
 
 @click.option(
     "--exit-after-one",
-    flag=True
+    is_flag=True,
+    help="Exit after running a single job from redis.",
 )
 @click.option(
     "--redis-url",

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -5,7 +5,7 @@ import click
 
 from virtool_workflow.options import apply_options
 from virtool_workflow.runtime import runtime
-from virtool_workflow.runtime.redis import run_jobs_from_redis
+from virtool_workflow.runtime.redis import run_jobs_from_redis, run_job_from_redis
 from virtool_workflow.testing.cli import test_main
 
 
@@ -24,15 +24,23 @@ def run(job_id, **kwargs):
 
 
 @click.option(
+    "--exit-after-one",
+    flag=True
+)
+@click.option(
     "--redis-url",
     default="redis://localhost:6317",
 )
 @apply_options
 @click.argument("list_name")
 @cli.command()
-def run_from_redis(**kwargs):
+def run_from_redis(exit_after_one, **kwargs):
     """Run jobs from redis for a workflow."""
-    asyncio.run(run_jobs_from_redis(**kwargs))
+    asyncio.run(
+        run_job_from_redis(**kwargs)
+        if exit_after_one is True
+        else run_jobs_from_redis(**kwargs)
+    )
 
 
 def cli_main(**kwargs):

--- a/virtool_workflow/cli.py
+++ b/virtool_workflow/cli.py
@@ -19,7 +19,7 @@ def cli():
 @click.argument("job_id")
 @cli.command()
 def run(job_id, **kwargs):
-    """Run a workflow."""    
+    """Run a workflow."""
     asyncio.run(runtime.start(job_id=job_id, **kwargs))
 
 

--- a/virtool_workflow/runtime/redis.py
+++ b/virtool_workflow/runtime/redis.py
@@ -64,7 +64,6 @@ async def _run_job_from_redis(
         await redis.wait_closed()
 
 
-
 async def run_job_from_redis(
     list_name: str,
     redis_url: str,
@@ -73,4 +72,3 @@ async def run_job_from_redis(
     """Run a single job from a redis list."""
     async with prepare_workflow(**config) as workflow:
         return await _run_job_from_redis(list_name, redis_url, workflow, **config)
-


### PR DESCRIPTION
Adds `--exit-after-one` flag to the `workflow run-from-redis` command.

When provided the process will exit after completing a single job.