### PR TITLE
fix: prevent excessive memory use when fetching input files

### DIFF
--- a/tests/api/mocks/mock_hmm_routes.py
+++ b/tests/api/mocks/mock_hmm_routes.py
@@ -62,7 +62,10 @@ async def get(request):
 
 @mock_routes.get('/hmms/files/profiles.hmm')
 async def download_hmm_profiles(request):
-    return FileResponse(HMM_PROFILES)
+    return FileResponse(HMM_PROFILES, headers={
+        "Content-Disposition": "attachment; filename='profiles.hmm'",
+        "Content-Type": "application/octet-stream"
+    })
 
 
 @mock_routes.get('/hmms/files/annotations.json.gz')
@@ -76,4 +79,7 @@ async def download_annotations(request):
 
         virtool_core.utils.compress_file(annotations_path, compressed_annotations_path)
 
-    return FileResponse(annotations_path)
+    return FileResponse(annotations_path, headers={
+        "Content-Disposition": "attachment; filename=annotations.json.gz",
+        "Content-Type": "application/octet-stream"
+    })

--- a/tests/api/mocks/mock_index_routes.py
+++ b/tests/api/mocks/mock_index_routes.py
@@ -124,7 +124,10 @@ async def download_index_files(request):
             "message": "Not Found"
         }, status=404)
 
-    return web.FileResponse(path)
+    return web.FileResponse(path, headers={
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        "Content-Type": "application/octet-stream"
+    })
 
 
 @mock_routes.patch("/indexes/{index_id}")

--- a/tests/api/mocks/mock_sample_routes.py
+++ b/tests/api/mocks/mock_sample_routes.py
@@ -110,7 +110,10 @@ async def download_reads_file(request):
 
     file_name = "paired_small_1.fq.gz" if filename == "reads_1.fq.gz" else "paired_small_2.fq.gz"
 
-    return FileResponse(ANALYSIS_TEST_FILES_DIR / file_name)
+    return FileResponse(ANALYSIS_TEST_FILES_DIR / file_name, headers={
+        "Content-Disposition": f"attachment; filename={file_name}",
+        "Content-Type": "application/octet-stream"
+    })
 
 
 @mock_routes.get("/samples/{sample_id}/caches/{key}/artifacts/{filename}")
@@ -228,4 +231,7 @@ async def download_cached_reads(request):
     file = (tmpdir / name)
     file.touch()
 
-    return FileResponse(file)
+    return FileResponse(file, headers={
+        "Content-Disposition": f"attachment; filename={name}",
+        "Content-Type": "application/octet-stream"
+    })

--- a/virtool_workflow/api/errors.py
+++ b/virtool_workflow/api/errors.py
@@ -57,6 +57,7 @@ async def raising_errors_by_status_code(
         accept = list(range(200, 299))
 
     response_json = None
+
     if response.content_type == "application/json":
         try:
             response_json = await response.json()

--- a/virtool_workflow/api/utils.py
+++ b/virtool_workflow/api/utils.py
@@ -12,7 +12,8 @@ from virtool_workflow.data_model.files import VirtoolFileFormat, VirtoolFile
 async def read_file_from_response(response, target_path: Path):
     async with raising_errors_by_status_code(response):
         async with aiofiles.open(target_path, "wb") as f:
-            await f.write(await response.read())
+            async for chunk in response.content.iter_chunked(4096):
+                await f.write(chunk)
 
     return target_path
 


### PR DESCRIPTION
Files were being completely loaded into memory due to `read()`.

The `read_file_from_response()` function was updated to write 4 MB chunks to file instead.