### PR TITLE
chore: remove .vim folder

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,6 +1,0 @@
-{
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.jediEnabled": false,
-  "python.formatting.provider": "black"
-}


### PR DESCRIPTION
Remove unnecessary `.vim` folder.

This commit is really to trigger major release. A previous commit had
breaking changes, but its message wasn't formatted correctly.

BREAKING CHANGE: Trigger a release for previous release 2.3.0.