### PR TITLE
test: use new runtime in status integration tests

### DIFF
--- a/tests/integration/_fixtures/workflows.py
+++ b/tests/integration/_fixtures/workflows.py
@@ -1,30 +1,28 @@
-import pytest
 from importlib import import_module
-from fixtures import FixtureScope
-from virtool_workflow.runtime.runtime import run_workflow
+from typing import Dict, Any
 
+import pytest
+
+from virtool_workflow._runtime import run_workflow
 
 
 @pytest.fixture
-async def base_config(job_id, jobs_api):
+async def base_config(jobs_api):
     return {
         "mem": 8,
         "proc": 2,
-        "job_id": job_id,
         "jobs_api_url": jobs_api
     }
 
 
 @pytest.fixture
-async def exec_workflow(base_config):
+async def exec_workflow(base_config: Dict[str, Any], job_id):
     import_module("virtool_workflow.builtin_fixtures")
     import_module("virtool_workflow.runtime.providers")
     import_module("virtool_workflow.analysis.fixtures")
 
     async def _exec_workflow(workflow, **kwargs):
         base_config.update(kwargs)
-        await run_workflow(workflow, base_config)
+        await run_workflow(base_config, job_id, workflow)
 
     return _exec_workflow
-
-


### PR DESCRIPTION
* Use hook decorator API in `configure_builtin_status_hooks`.
* Configure hooks in `run_workflow` so they are ready to be used in tests.