### PR TITLE
Fix samples provider

### DIFF
--- a/virtool_workflow/_executor.py
+++ b/virtool_workflow/_executor.py
@@ -38,6 +38,7 @@ async def execute(
     scope["error"] = None
     scope["logger"] = logger
     scope["workflow"] = workflow
+    scope["current_step"] = None
 
     await on_workflow_start.trigger(scope)
 

--- a/virtool_workflow/_runtime.py
+++ b/virtool_workflow/_runtime.py
@@ -61,6 +61,7 @@ def configure_workflow(
     for name in (
         "virtool_workflow.builtin_fixtures",
         "virtool_workflow.analysis.fixtures",
+        "virtool_workflow.runtime.providers",
     ):
         module = import_module(name)
         logger.debug(f"Imported {module}")


### PR DESCRIPTION
Provider fixtures weren't being intialised during workflow start. To fix, initialize provider fixtures during workflow startup.

Also, fix exception when trying to report error to API with no `current_step` fixture value defined.