### PR TITLE
Add tests of executor implementation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -833,6 +833,20 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 pytest = ">=2.9"
 
 [[package]]
+name = "pytest-mock"
+version = "3.7.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "pytest-picked"
 version = "0.4.6"
 description = "Run the tests related to the changed files"
@@ -1250,7 +1264,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fe2ecdf10b43d8dbdf6b21f7bdae3d1277aa13f387d9e3ce31ab013c7d5a40ab"
+content-hash = "c0a9a8263e7528759c3c71441f4e443501876f451bad8dc4f568838e3997a193"
 
 [metadata.files]
 aiofiles = [
@@ -2125,6 +2139,10 @@ pytest-forked = [
 pytest-instafail = [
     {file = "pytest-instafail-0.4.2.tar.gz", hash = "sha256:19273fdf3f0f9a1cb4b7a0bc8aa1bdaaf6b0f62a681b693d5eca4626abc99782"},
     {file = "pytest_instafail-0.4.2-py2.py3-none-any.whl", hash = "sha256:1ec440a177be89a9ed2759dade8e1f7a2b95bac74ae81dc91318d309bf4ebd4f"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},
+    {file = "pytest_mock-3.7.0-py3-none-any.whl", hash = "sha256:6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231"},
 ]
 pytest-picked = [
     {file = "pytest-picked-0.4.6.tar.gz", hash = "sha256:e1ec7aee5d2cd3a91f676fd0afd7620a26c0ccc21e604152bbc5137f430e6c00"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ motor = "^2.5.1"
 pytest-docker-compose = "^3.2.1"
 black = "22.3.0"
 pre-commit = "^2.18.1"
+pytest-mock = "^3.7.0"
 
 [tool.poetry.scripts]
 run-workflow = "virtool_workflow.cli:cli_main"

--- a/tests/fixtures/workflow.py
+++ b/tests/fixtures/workflow.py
@@ -1,6 +1,14 @@
 import pytest
 from virtool_workflow import workflow
 
+from fixtures import FixtureScope
+
+
+@pytest.fixture
+async def empty_scope():
+    async with FixtureScope() as scope:
+        yield scope
+
 
 @pytest.fixture
 def test_workflow():

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,11 +1,11 @@
-from asyncio import CancelledError, create_task, sleep
+from asyncio import CancelledError
 
 import pytest
 from pytest_mock import MockerFixture
 from virtool_workflow import Workflow, hooks
 from virtool_workflow._executor import execute
 from virtool_workflow.events import Events
-from virtool_workflow.execution.states import WAITING, RUNNING, COMPLETE, ERROR
+from virtool_workflow.execution.states import COMPLETE, ERROR, RUNNING, WAITING
 
 from fixtures import FixtureScope
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,129 @@
+from asyncio import CancelledError, create_task, sleep
+
+import pytest
+from pytest_mock import MockerFixture
+from virtool_workflow import Workflow, hooks
+from virtool_workflow._executor import execute
+from virtool_workflow.events import Events
+from virtool_workflow.execution.states import WAITING, RUNNING, COMPLETE, ERROR
+
+from fixtures import FixtureScope
+
+
+@pytest.fixture
+def success_workflow():
+    def dummy_step():
+        ...
+
+    workflow = Workflow()
+
+    for _ in range(3):
+        workflow.step(dummy_step)
+
+    return workflow
+
+
+@pytest.fixture
+def failure_workflow():
+    workflow = Workflow()
+
+    @workflow.step
+    async def fail():
+        raise ValueError()
+
+    return workflow
+
+
+async def test_execute_does_trigger_success_hooks(
+    success_workflow: Workflow, empty_scope: FixtureScope, mocker: MockerFixture
+):
+    mocks = {
+        hook.name: mocker.patch.object(hook, "trigger", autospec=True)
+        for hook in (
+            hooks.on_finish,
+            hooks.on_success,
+            hooks.on_workflow_start,
+            hooks.on_result,
+        )
+    }
+
+    # add a result so that `on_result` hook does trigger
+    empty_scope["results"] = {}
+
+    await execute(success_workflow, empty_scope, Events())
+
+    for name, mock in mocks.items():
+        try:
+            mock.assert_called_once()
+        except AssertionError as e:
+            raise AssertionError(f"{name} was not triggered") from e
+
+
+async def test_execute_does_trigger_step_hooks(
+    success_workflow: Workflow, empty_scope: FixtureScope, mocker: MockerFixture
+):
+    on_start = mocker.patch.object(hooks.on_step_start, "trigger", autospec=True)
+    on_finish = mocker.patch.object(hooks.on_step_finish, "trigger", autospec=True)
+
+    await execute(success_workflow, empty_scope, Events())
+
+    assert on_start.call_count == len(success_workflow.steps)
+    assert on_finish.call_count == len(success_workflow.steps)
+
+
+async def test_execute_does_trigger_failure_hooks(
+    failure_workflow, empty_scope: FixtureScope, mocker: MockerFixture
+):
+    on_failure = mocker.patch.object(hooks.on_failure, "trigger", autospec=True)
+    on_finish = mocker.patch.object(hooks.on_finish, "trigger", autospec=True)
+    on_error = mocker.patch.object(hooks.on_error, "trigger", autospec=True)
+
+    await execute(failure_workflow, empty_scope, Events())
+
+    on_failure.assert_called_once()
+    on_finish.assert_called_once()
+    on_error.assert_called_once()
+
+    assert isinstance(empty_scope["error"], ValueError)
+    assert empty_scope["state"] == ERROR
+
+
+async def test_execute_does_trigger_on_cancelled_hook_after_cancelled_event(
+    empty_scope: FixtureScope, mocker: MockerFixture
+):
+    workflow = Workflow()
+
+    @workflow.step
+    async def simulate_cancel():
+        raise CancelledError()
+
+    on_cancel = mocker.patch.object(hooks.on_cancelled, "trigger", autospec=True)
+
+    events = Events()
+    events.cancelled.set()
+
+    await execute(workflow, empty_scope, events)
+
+    on_cancel.assert_called_once()
+
+
+async def test_execute_does_update_state_fixture(
+    empty_scope: FixtureScope, mocker: MockerFixture
+):
+    state = await empty_scope.get_or_instantiate("state")
+    assert state == WAITING
+
+    workflow = Workflow()
+
+    @workflow.step
+    def running(state):
+        assert state == RUNNING
+
+    @hooks.on_finish(once=True)
+    def check_complete(state):
+        assert state == COMPLETE
+
+    await execute(workflow, empty_scope, Events())
+
+    assert empty_scope["error"] is None
+    assert empty_scope["state"] == COMPLETE

--- a/virtool_workflow/_executor.py
+++ b/virtool_workflow/_executor.py
@@ -115,6 +115,13 @@ async def run_step_with_hooks(scope: FixtureScope, step: WorkflowStep):
         scope["current_step"] = None
 
 
+@fixture
+def state(scope):
+    if "state" not in scope:
+        scope["state"] = states.WAITING
+    return scope["state"]
+
+
 @fixture(scope="function")
 def progress(step_number, workflow):
     return float(step_number) / float(len(workflow.steps))


### PR DESCRIPTION
Tests that life-cycle hooks get triggered in the correct order and under the correct circumstances. 

The bulk of the life-cycle management has been extracted out to a context manager `workflow_lifecycle`.