### PR TITLE
chore: avoid logging JSON responses

### DIFF
--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -1,16 +1,14 @@
 import asyncio
-import traceback
 import functools
 import logging
-import pprint
-from typing import Protocol, Optional
+import traceback
+from typing import Optional, Protocol
 
 import aiohttp
-
 from fixtures import fixture
 
-from ..data_model import Job, Status, State
-from .. import Workflow, WorkflowStep
+from .. import WorkflowStep
+from ..data_model import Job, State, Status
 from .errors import (
     JobAlreadyAcquired,
     JobsAPIServerError,
@@ -145,7 +143,7 @@ async def _push_status(
         "progress": int(progress * 100),
     }
 
-    logger.info(f"Status: {pprint.pformat(payload)}")
+    logger.info(f"Status: {step_name}, {state}")
 
     async with http.post(
         f"{jobs_api_connection_string}/jobs/{job.id}/status", json=payload

--- a/virtool_workflow/api/samples.py
+++ b/virtool_workflow/api/samples.py
@@ -1,26 +1,23 @@
 import logging
-import pprint
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 import aiohttp
-
 from virtool_workflow.analysis.utils import ReadPaths, make_read_paths
 from virtool_workflow.api.errors import (
-    raising_errors_by_status_code,
     AlreadyFinalized,
     JobsAPIServerError,
+    raising_errors_by_status_code,
 )
-from virtool_workflow.api.utils import upload_file_via_put, read_file_from_response
+from virtool_workflow.api.utils import read_file_from_response, upload_file_via_put
 from virtool_workflow.data_model import Sample
-from virtool_workflow.data_model.files import VirtoolFileFormat, VirtoolFile
+from virtool_workflow.data_model.files import VirtoolFile, VirtoolFileFormat
 
 logger = logging.getLogger(__name__)
 
 
 async def _make_sample_from_response(response) -> Sample:
     async with raising_errors_by_status_code(response) as sample_json:
-        logger.debug(pprint.pformat(sample_json))
         return Sample(
             id=sample_json["id"],
             name=sample_json["name"],

--- a/virtool_workflow/execution/hooks.py
+++ b/virtool_workflow/execution/hooks.py
@@ -1,7 +1,6 @@
 import logging
-import pprint
 from asyncio import gather
-from typing import List, Any, Callable
+from typing import Any, Callable, List
 
 from fixtures import FixtureScope
 from virtool_workflow.utils import coerce_to_coroutine_function


### PR DESCRIPTION
Limit logs to key information.