### PR TITLE
fix: retry requests on when connection refused

### DIFF
--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,0 +1,37 @@
+import logging
+
+from virtool_workflow.api.utils import retry
+
+
+async def test_retry(caplog):
+    caplog.set_level(logging.INFO)
+
+    class Retry:
+        def __init__(self):
+            self.attempt = 0
+            self.args = []
+            self.kwargs = {}
+
+        @retry
+        async def do_something(self, *args, **kwargs):
+            self.attempt += 1
+
+            if self.attempt == 1:
+                raise ConnectionRefusedError
+
+            self.args = args
+            self.kwargs = kwargs
+
+    obj = Retry()
+
+    await obj.do_something("hello", this_is_a_test=True)
+
+    assert obj.attempt == 2
+    assert obj.args == ("hello",)
+    assert obj.kwargs == {"this_is_a_test": True}
+
+    for record in caplog.records:
+        assert record.levelno == logging.INFO
+        assert (
+            record.msg == "Encountered ConnectionRefusedError. Retrying in 5 seconds."
+        )

--- a/virtool_workflow/api/analysis.py
+++ b/virtool_workflow/api/analysis.py
@@ -2,6 +2,7 @@
 A data provider for Virtool analysis based on HTTP communication with the Virtool job API.
 
 """
+import asyncio
 import logging
 from pathlib import Path
 from typing import Dict, Any, Tuple, List
@@ -9,9 +10,10 @@ from typing import Dict, Any, Tuple, List
 import aiofiles
 import aiohttp
 import dateutil.parser
+from aiohttp import ClientConnectorError
 
 from virtool_workflow.api.errors import raising_errors_by_status_code
-from virtool_workflow.api.utils import upload_file_via_put
+from virtool_workflow.api.utils import upload_file_via_put, retry
 from virtool_workflow.data_model.analysis import Analysis
 from virtool_workflow.data_model.files import VirtoolFile, VirtoolFileFormat
 
@@ -132,6 +134,7 @@ class AnalysisProvider:
 
         return target_path
 
+    @retry
     async def upload_result(self, result: Dict[str, Any]) -> Tuple[Analysis, dict]:
         """
         Upload the results dict for the analysis.

--- a/virtool_workflow/api/analysis.py
+++ b/virtool_workflow/api/analysis.py
@@ -2,7 +2,6 @@
 A data provider for Virtool analysis based on HTTP communication with the Virtool job API.
 
 """
-import asyncio
 import logging
 from pathlib import Path
 from typing import Dict, Any, Tuple, List
@@ -10,7 +9,6 @@ from typing import Dict, Any, Tuple, List
 import aiofiles
 import aiohttp
 import dateutil.parser
-from aiohttp import ClientConnectorError
 
 from virtool_workflow.api.errors import raising_errors_by_status_code
 from virtool_workflow.api.utils import upload_file_via_put, retry

--- a/virtool_workflow/utils.py
+++ b/virtool_workflow/utils.py
@@ -1,6 +1,9 @@
-from typing import Callable
-from inspect import iscoroutinefunction
 from functools import wraps
+from inspect import iscoroutinefunction
+from logging import getLogger
+from typing import Callable
+
+logger = getLogger(__name__)
 
 
 def coerce_to_coroutine_function(func: Callable):


### PR DESCRIPTION
This is probably happening during brief interruptions in API connectivity.

Try five times to retry requests, waiting five seconds between each attempt. Implement logic as a decorator that can wrap API provider methods.

* Resolves VIR-1422.
* Resolves VIR-1429.