### PR TITLE
Add index.reference field

### DIFF
--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -64,6 +64,17 @@ def acquire_job(http: ClientSession, jobs_api_connection_string: str):
     return _job_provider
 
 
+async def ping(http: ClientSession, jobs_api_connection_string: str, job_id: str):
+    async with http.patch(
+        f"{jobs_api_connection_string}/jobs/{job_id}/ping", json={"acquired": True}
+    ) as response:
+
+        async with raising_errors_by_status_code(
+            response, status_codes_to_exceptions={400: JobAlreadyAcquired}
+        ) as resp_json:
+            return WFJob(**resp_json)
+
+
 @fixture(scope="function")
 async def push_status(
     http,

--- a/virtool_workflow/data_model/indexes.py
+++ b/virtool_workflow/data_model/indexes.py
@@ -50,6 +50,7 @@ class WFIndex:
 
         self.id = index.id
         self.manifest = index.manifest
+        self.reference = index.reference
 
         self._sequence_lengths: Dict[str, int] = {}
         self._sequence_otu_map: Dict[str, str] = {}

--- a/virtool_workflow/runtime/run.py
+++ b/virtool_workflow/runtime/run.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict
 
+import pkg_resources
 from pyfixtures import FixtureScope, runs_in_new_fixture_context
 from virtool_core.logging import configure_logs
 from virtool_core.redis import configure_redis
@@ -121,6 +122,10 @@ async def start_runtime(
     timeout: int,
     work_path: Path,
 ):
+    version = pkg_resources.get_distribution("virtool-workflow").version
+
+    logger.info(f"Using virtool-workflow {version}")
+
     configure_logs(dev)
     configure_sentry(sentry_dsn)
 


### PR DESCRIPTION
* A `reference` field is required on the `WFIndex` class for the build-index workflow. Add it.
* Log the `virtool-workflow` version on workflow start.