### PR TITLE
Matthewcurtis1999/vir 1864 fix docs builds for virtool workflow

### DIFF
--- a/docs/_ext/autofixture.py
+++ b/docs/_ext/autofixture.py
@@ -41,7 +41,7 @@ class FixtureDocumenter(FunctionDocumenter):
     def can_document_member(
         cls, member: Any, membername: str, isattr: bool, parent: Any
     ) -> bool:
-        return isinstance(member, fixtures.Fixture)
+        return isinstance(member, pyfixtures.Fixture)
 
     def format_args(self, **kwargs: Any) -> str:
         args = super(FixtureDocumenter, self).format_args(**kwargs)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -56,6 +56,7 @@ API Reference
 
 .. automodule:: virtool_workflow.analysis.skewer
     :members:
+
 ``virtool_workflow.config.configuration.fixtures``
 ==================================================
 
@@ -81,7 +82,7 @@ API Reference
     :members:
 
 ``virtool_workflow.data_model.analysis``
-=======================================
+==============================================
 
 .. automodule:: virtool_workflow.data_model.analysis
     :members:

--- a/virtool_workflow/data_model/subtractions.py
+++ b/virtool_workflow/data_model/subtractions.py
@@ -32,16 +32,17 @@ class WFSubtraction(Subtraction):
     @property
     def bowtie2_index_path(self) -> Path:
         """
-        The path to Bowtie2 prefix in the the running workflow's work_path
+        The path to Bowtie2 prefix in the running workflow's work_path
 
         For example, ``<work_path>/subtractions/<id>/subtraction`` refers to the Bowtie2
         index files:
-            - ``<work_path>/subtractions/<id>/subtraction.1.bt2``
-            - ``<work_path>/subtractions/<id>/subtraction.2.bt2``
-            - ``<work_path>/subtractions/<id>/subtraction.3.bt2``
-            - ``<work_path>/subtractions/<id>/subtraction.4.bt2``
-            - ``<work_path>/subtractions/<id>/subtraction.rev.1.bt2``
-            - ``<work_path>/subtractions/<id>/subtraction.rev.2.bt2``
+
+        - ``<work_path>/subtractions/<id>/subtraction.1.bt2``
+        - ``<work_path>/subtractions/<id>/subtraction.2.bt2``
+        - ``<work_path>/subtractions/<id>/subtraction.3.bt2``
+        - ``<work_path>/subtractions/<id>/subtraction.4.bt2``
+        - ``<work_path>/subtractions/<id>/subtraction.rev.1.bt2``
+        - ``<work_path>/subtractions/<id>/subtraction.rev.2.bt2``
 
         """
         return self.path / "subtraction"

--- a/virtool_workflow/hooks.py
+++ b/virtool_workflow/hooks.py
@@ -21,7 +21,7 @@ Triggered before each workflow step is executed.
 
 The :class:`WorkflowStep` object is available via the `current_step` fixture.
 
-.. code_block:: python
+.. code-block:: python
 
     @on_step_start
     async def use_step(current_step):
@@ -34,8 +34,10 @@ Triggered after each workflow step is executed.
 
 The :class:`WorkflowStep` object is available via the `current_step` fixture.
 
-@on_step_finish
-async def handle_step_finish(current_step):
+.. code-block:: python
+
+    @on_step_finish
+    async def handle_step_finish(current_step):
     ...
 """
 


### PR DESCRIPTION
Docs now build locally, however 11 warnings remain:

- 2 are from undefined labels (samples and subtraction) in /virtool-workflow/docs/fixtures.rst:51:

- 1 for autofixture not being included in any toctree

- 5 are from modules not existing 

- 1 is from a fail to import analysis because of an exception is raised (appears to be dependancy based)

- 2 are from duplicate doc string descriptions for download_input_file (virtool-workflow/virtool_workflow/api/uploads.py, fixtures.rst:313, and reference.rst:114
