### PR TITLE
fix: clean api ping logs

### DIFF
--- a/virtool_workflow/api/jobs.py
+++ b/virtool_workflow/api/jobs.py
@@ -73,15 +73,9 @@ async def ping(http: ClientSession, jobs_api_connection_string: str, job_id: str
     :param job_id: The id of the job to ping.
     :return: The job.
     """
-    print(http)
 
-    async with http.put(f"{jobs_api_connection_string}/jobs/{job_id}/ping") as resp:
-        print(resp.status)
-        print(await resp.text())
-
-    print("PING")
-
-    logger.info("Sent ping")
+    async with http.put(f"{jobs_api_connection_string}/jobs/{job_id}/ping"):
+        logger.info("Sent ping")
 
 
 @fixture(scope="function")


### PR DESCRIPTION
eliminated all print calls so we only get the  ```2023-09-06 20:56:37  jobs        INFO     Sent ping``` log.

Reiterating what I said in linear: 
There may still be a problem, I noticed in the log provided and my own log after creating a sample, that after all of the print calls there was no log of " Sent ping". Maybe by eliminating the print calls, the log will show up?